### PR TITLE
add an option controlling the position of new bookmarks

### DIFF
--- a/src/main/java/mezz/jei/bookmarks/BookmarkList.java
+++ b/src/main/java/mezz/jei/bookmarks/BookmarkList.java
@@ -46,7 +46,7 @@ public class BookmarkList implements IIngredientGridSource {
 	public <T> boolean add(T ingredient) {
 		Object normalized = normalize(ingredient);
 		if (!contains(normalized)) {
-			if (addToLists(normalized, true)) {
+			if (addToLists(normalized, Config.isAddingBookmarksToFront())) {
 				notifyListenersOfChange();
 				saveBookmarks();
 				return true;

--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -193,6 +193,10 @@ public final class Config {
 	public static boolean isSearchTreeBuildingAsync() {
 		return values.asyncSearchTreeBuilding;
 	}
+	
+	public static boolean isAddingBookmarksToFront() {
+		return values.addBookmarksToFront;
+	}
 
 	public static boolean isUltraLowMemoryMode() {
 		return values.ultraLowMemoryUsage;
@@ -434,6 +438,8 @@ public final class Config {
 		values.ultraLowMemoryUsage = config.getBoolean(CATEGORY_ADVANCED, "ultraLowMemoryUsage", defaultValues.ultraLowMemoryUsage);
 
 		values.asyncSearchTreeBuilding = config.getBoolean(CATEGORY_ADVANCED, "asyncSearchTreeBuilding", defaultValues.asyncSearchTreeBuilding);
+
+		values.addBookmarksToFront = config.getBoolean(CATEGORY_ADVANCED, "addBookmarksToFront", defaultValues.addBookmarksToFront);
 
 		values.giveMode = config.getEnum("giveMode", CATEGORY_ADVANCED, defaultValues.giveMode, GiveMode.values());
 

--- a/src/main/java/mezz/jei/config/ConfigValues.java
+++ b/src/main/java/mezz/jei/config/ConfigValues.java
@@ -10,6 +10,7 @@ public class ConfigValues {
 	public boolean centerSearchBarEnabled = false;
 	public boolean ultraLowMemoryUsage = false;
 	public boolean asyncSearchTreeBuilding = true;
+	public boolean addBookmarksToFront = false;
 	public GiveMode giveMode = GiveMode.MOUSE_PICKUP;
 	public String modNameFormat = Config.parseFriendlyModNameFormat(Config.defaultModNameFormatFriendly);
 	public int maxColumns = 100;

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -141,6 +141,9 @@ config.jei.misc.comment=Miscellaneous config options
 config.jei.advanced.asyncSearchTreeBuilding=Async Search Tree Building
 config.jei.advanced.asyncSearchTreeBuilding.comment=Builds search trees on multiple threads concurrently, turn this off if you're experiencing extremely high load on your CPU when loading JEI
 
+config.jei.advanced.addBookmarksToFront=Prepend New Bookmarks
+config.jei.advanced.addBookmarksToFront.comment=When enabled, adds new bookmarks to the front of the bookmark list
+
 config.jei.misc.mouseClickToSeeRecipes=Mouse Click to See Recipes/Usages
 config.jei.misc.mouseClickToSeeRecipes.comment=Disable to disallow mouse clicks to see recipes and usages when hovering over an ingredient
 


### PR DESCRIPTION
Adds a new config boolean controlling where new bookmarks are added to (either the start or the end of the list).
defaults to false, meaning that new bookmarks will be added to the end of the list.