### PR TITLE
move bookmark file location to instance root

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -334,11 +334,24 @@ public final class Config {
 			}
 		}
 
+		bookmarkFile = new File("./", "bookmarks.ini");
+		File oldBookmarkFile = new File(jeiConfigurationDir, "bookmarks.ini");
+		if (oldBookmarkFile.exists() && !bookmarkFile.exists()) {
+			try {
+				if (!oldBookmarkFile.renameTo(bookmarkFile)) {
+					Log.get().error("Could not move the old bookmark file from {} to {}", jeiConfigurationDir, "./");
+					return;
+				}
+			} catch (SecurityException e) {
+				Log.get().error("Could not move the old bookmark file from {} to {}", jeiConfigurationDir, "./", e);
+				return;
+			}
+		}
+
 		final File configFile = new File(jeiConfigurationDir, "jei.cfg");
 		final File itemBlacklistConfigFile = new File(jeiConfigurationDir, "itemBlacklist.cfg");
 		final File searchColorsConfigFile = new File(jeiConfigurationDir, "searchColors.cfg");
 		final File worldConfigFile = new File(jeiConfigurationDir, "worldSettings.cfg");
-		bookmarkFile = new File(jeiConfigurationDir, "bookmarks.ini");
 		worldConfig = new Configuration(worldConfigFile, "0.1.0");
 		config = new LocalizedConfiguration(configKeyPrefix, configFile, "0.4.0");
 		itemBlacklistConfig = new LocalizedConfiguration(configKeyPrefix, itemBlacklistConfigFile, "0.1.0");

--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -334,7 +334,7 @@ public final class Config {
 			}
 		}
 
-		bookmarkFile = new File("./", "bookmarks.ini");
+		bookmarkFile = new File("./", "hei_bookmarks.ini");
 		File oldBookmarkFile = new File(jeiConfigurationDir, "bookmarks.ini");
 		if (oldBookmarkFile.exists() && !bookmarkFile.exists()) {
 			try {


### PR DESCRIPTION
Changes the `bookmarks.ini` file position from the default jei directory `./config/jei` to `./`.
This prevents pack makers from accidentally shipping their bookmarks file with the config folder (pack makers can still ship it if they select the file specifically), and prevents pack updates from wiping the players bookmarks.