### PR TITLE
Order by metadata when orderIndex is the same

### DIFF
--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -112,6 +112,15 @@ public interface IIngredientHelper<V> {
 	String getResourceId(V ingredient);
 
 	/**
+	 * Return the metadata value for the item
+	 *
+	 * @param ingredient The ingredient to cheat in. Do not edit this ingredient.
+	 * @return the metadata value for an ingredient
+	 * @since JEI 4.8.3
+	 */
+	int getMetadata(V ingredient);
+
+	/**
 	 * Called when a player is in cheat mode and clicks an ingredient in the list.
 	 *
 	 * @param ingredient The ingredient to cheat in. Do not edit this ingredient.

--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -117,7 +117,7 @@ public interface IIngredientHelper<V> {
 	 * @return the metadata value for an ingredient
 	 * @since JEI 4.8.3
 	 */
-	int getMetadata(V ingredient);
+	default int getMetadata(V ingredient) { return 0; };
 
 	/**
 	 * Called when a player is in cheat mode and clicks an ingredient in the list.

--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -114,7 +114,6 @@ public interface IIngredientHelper<V> {
 	/**
 	 * Return the metadata value for the item
 	 *
-	 * @param ingredient The ingredient to cheat in. Do not edit this ingredient.
 	 * @return the metadata value for an ingredient
 	 * @since JEI 4.8.3
 	 */

--- a/src/main/java/mezz/jei/gui/ingredients/IIngredientListElement.java
+++ b/src/main/java/mezz/jei/gui/ingredients/IIngredientListElement.java
@@ -32,6 +32,8 @@ public interface IIngredientListElement<V> {
 
 	String getResourceId();
 
+	int getMetadata();
+
 	boolean isVisible();
 
 	void setVisible(boolean visible);

--- a/src/main/java/mezz/jei/ingredients/IngredientListElement.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientListElement.java
@@ -28,6 +28,7 @@ public class IngredientListElement<V> implements IIngredientListElement<V> {
 	private final Object modNames; // Can be String or String[]
 	private final String displayName;
 	private final String resourceId;
+	private final int metadata;
 
 	private boolean visible = true;
 
@@ -59,6 +60,7 @@ public class IngredientListElement<V> implements IIngredientListElement<V> {
 				canonicalizedStringArrays.addOrGet(Arrays.stream((String[]) this.modIds).map(modIdHelper::getModNameForModId).map(String::intern).toArray(String[]::new));
 		this.displayName = IngredientInformation.getDisplayName(ingredient, ingredientHelper);
 		this.resourceId = LegacyUtil.getResourceId(ingredient, ingredientHelper);
+		this.metadata = ingredientHelper.getMetadata(ingredient);
 	}
 
 	@Override
@@ -150,6 +152,11 @@ public class IngredientListElement<V> implements IIngredientListElement<V> {
 	@Override
 	public String getResourceId() {
 		return resourceId;
+	}
+
+	@Override
+	public int getMetadata() {
+		return metadata;
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/ingredients/IngredientListElementComparator.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientListElementComparator.java
@@ -30,6 +30,13 @@ public final class IngredientListElementComparator implements Comparator<IIngred
 
 			final int orderIndex1 = o1.getOrderIndex();
 			final int orderIndex2 = o2.getOrderIndex();
+
+			if (orderIndex1 == orderIndex2) {
+				final int metadata1 = o1.getMetadata();
+				final int metadata2 = o2.getMetadata();
+				return Integer.compare(metadata1, metadata2);
+			}
+
 			return Integer.compare(orderIndex1, orderIndex2);
 		} else if (modName1.equals(Constants.MINECRAFT_NAME)) {
 			return -1;

--- a/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
+++ b/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
@@ -55,10 +55,6 @@ public class DebugIngredientHelper implements IIngredientHelper<DebugIngredient>
 		return "debug_" + ingredient.getNumber();
 	}
 
-    @Override
-    public int getMetadata(DebugIngredient ingredient) {
-        return ingredient.getNumber();
-    }
 
     @Override
 	public ItemStack getCheatItemStack(DebugIngredient ingredient) {

--- a/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
+++ b/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
@@ -3,7 +3,6 @@ package mezz.jei.plugins.jei.ingredients;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.util.Collections;
-import java.util.Random;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;

--- a/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
+++ b/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
@@ -3,6 +3,7 @@ package mezz.jei.plugins.jei.ingredients;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.util.Collections;
+import java.util.Random;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -55,7 +56,12 @@ public class DebugIngredientHelper implements IIngredientHelper<DebugIngredient>
 		return "debug_" + ingredient.getNumber();
 	}
 
-	@Override
+    @Override
+    public int getMetadata(DebugIngredient ingredient) {
+        return ingredient.getNumber();
+    }
+
+    @Override
 	public ItemStack getCheatItemStack(DebugIngredient ingredient) {
 		EntityPlayerSP player = Minecraft.getMinecraft().player;
 		if (player != null) {

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/enchant/EnchantDataHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/enchant/EnchantDataHelper.java
@@ -86,7 +86,12 @@ public class EnchantDataHelper implements IIngredientHelper<EnchantmentData> {
 		return registryName.getPath();
 	}
 
-	@Override
+    @Override
+    public int getMetadata(EnchantmentData ingredient) {
+        return 0;
+    }
+
+    @Override
 	public ItemStack getCheatItemStack(EnchantmentData ingredient) {
 		return cache.getEnchantedBook(ingredient);
 	}

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/enchant/EnchantDataHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/enchant/EnchantDataHelper.java
@@ -87,11 +87,6 @@ public class EnchantDataHelper implements IIngredientHelper<EnchantmentData> {
 	}
 
     @Override
-    public int getMetadata(EnchantmentData ingredient) {
-        return 0;
-    }
-
-    @Override
 	public ItemStack getCheatItemStack(EnchantmentData ingredient) {
 		return cache.getEnchantedBook(ingredient);
 	}

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
@@ -92,11 +92,6 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 	}
 
     @Override
-    public int getMetadata(FluidStack ingredient) {
-        return 0;
-    }
-
-    @Override
 	public ItemStack getCheatItemStack(FluidStack ingredient) {
 		IFluidHandlerItem handler = Config.getDefaultFluidContainerItem().getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
 		ingredient = ingredient.copy();

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
@@ -91,7 +91,12 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 		return fluidResourceName.getPath();
 	}
 
-	@Override
+    @Override
+    public int getMetadata(FluidStack ingredient) {
+        return 0;
+    }
+
+    @Override
 	public ItemStack getCheatItemStack(FluidStack ingredient) {
 		IFluidHandlerItem handler = Config.getDefaultFluidContainerItem().getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
 		ingredient = ingredient.copy();

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
@@ -125,6 +125,11 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 	}
 
 	@Override
+	public int getMetadata(ItemStack ingredient) {
+		return ingredient.getMetadata();
+	}
+
+	@Override
 	public ItemStack getCheatItemStack(ItemStack ingredient) {
 		return ingredient;
 	}


### PR DESCRIPTION
Closes #26 

Fixes an issue where items that have the same orderIndex (like vanilla stone and wool for example) are shown in a random order.


Before
![image](https://user-images.githubusercontent.com/18713839/176339293-3030b5c2-fe93-41eb-983e-242dadc62390.png)  
![image](https://user-images.githubusercontent.com/18713839/176339338-70377a29-9417-467a-ace7-49e8d1bf6b15.png)
![image](https://user-images.githubusercontent.com/18713839/176339811-5b2fd8c9-0b4c-41e7-a5d7-bd372def0178.png)
![image](https://user-images.githubusercontent.com/18713839/176339919-6caf6b44-5f51-4e51-abaa-ffa07611b4d2.png)


After
![image](https://user-images.githubusercontent.com/18713839/176339575-dbc34a6a-f321-47f2-bc44-134066ed70a5.png)
![image](https://user-images.githubusercontent.com/18713839/176339611-962e3b0f-9973-4679-9f1b-1e798c3ed0ee.png)
![image](https://user-images.githubusercontent.com/18713839/176339738-e554ba7b-16fa-4684-81ca-d634864871e6.png)
![image](https://user-images.githubusercontent.com/18713839/176339943-5c1af261-8eb2-4bbe-9299-5e8730206e48.png)
![image](https://user-images.githubusercontent.com/18713839/176340310-73cd27c2-4396-44e5-a635-73f837881715.png)



