### PR TITLE
Correct "fix" for Optifine

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -11,12 +11,15 @@ import java.util.Locale;
 import java.util.Set;
 
 import mezz.jei.util.ReflectionUtil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.ConfigCategory;
@@ -315,7 +318,11 @@ public final class Config {
 	}
 
 	public static boolean bufferIngredientRenders() {
-		return !isOptifineInstalled && values.bufferIngredientRenders;
+		boolean fastRender = false;
+		if(isOptifineInstalled) {
+			fastRender = ObfuscationReflectionHelper.getPrivateValue(GameSettings.class, Minecraft.getMinecraft().gameSettings, "ofFastRender");
+		}
+		return !fastRender && values.bufferIngredientRenders;
 	}
 
 	public static boolean mouseClickToSeeRecipe() {


### PR DESCRIPTION
Turning off bufferIngredientRenders only when Fast Render is enabled