### PR TITLE
Don't rebuild disabled search trees

### DIFF
--- a/src/main/java/mezz/jei/search/PrefixedSearchable.java
+++ b/src/main/java/mezz/jei/search/PrefixedSearchable.java
@@ -38,6 +38,8 @@ public class PrefixedSearchable implements ISearchable<IIngredientListElement<?>
 
     @Override
     public void submit(IIngredientListElement<?> ingredient) {
+        if(prefixInfo.getMode() == Config.SearchMode.DISABLED)
+            return;
         Collection<String> strings = prefixInfo.getStrings(ingredient);
         for (String string : strings) {
             searchStorage.put(string, ingredient);
@@ -46,6 +48,8 @@ public class PrefixedSearchable implements ISearchable<IIngredientListElement<?>
 
     @Override
     public void submitAll(NonNullList<IIngredientListElement> ingredients) {
+        if(prefixInfo.getMode() == Config.SearchMode.DISABLED)
+            return;
         if (IngredientFilter.firstBuild) {
             start();
             ProgressManager.ProgressBar progressBar = null;


### PR DESCRIPTION
Reverts commit https://github.com/CleanroomMC/HadEnoughItems/commit/6065fcfcff1b2c027b36bb1beeae51a8fb689538. This change causes potential performance issues with dynamic resources as the color search tree sequentially loads every item model. I don't see a good reason to be spending CPU time on building search trees the user doesn't wish to use.