### PR TITLE
Smarter reload logic when reloading resource packs

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -84,7 +84,7 @@ public final class Config {
 	private static final Set<String> itemBlacklist = new HashSet<>();
 	private static final String[] defaultItemBlacklist = new String[]{};
 
-	private static boolean needToRebuildSearchTree;
+	public static boolean needToRebuildSearchTree;
 
 	private Config() {
 

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
@@ -89,6 +89,10 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 		return true;
 	}
 
+	public void invalidateBuffer() {
+		this.guiIngredientSlots.invalidateBuffer();
+	}
+
 	public Rectangle getArea() {
 		return area;
 	}

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
@@ -89,6 +89,10 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 		return true;
 	}
 
+	public void invalidateBuffer() {
+		this.ingredientGrid.invalidateBuffer();
+	}
+
 	public Rectangle getArea() {
 		return this.area;
 	}

--- a/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
@@ -74,6 +74,10 @@ public class IngredientListOverlay implements IIngredientListOverlay, IMouseHand
 		updateLayout(true);
 	}
 
+	public void invalidateBuffer() {
+		this.contents.invalidateBuffer();
+	}
+
 	public boolean isListDisplayed() {
 		return Config.isOverlayEnabled() && this.guiProperties != null && this.hasRoom;
 	}

--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -119,10 +119,15 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 		if (Config.doesSearchTreeNeedReload()) {
 			firstBuild = true;
 			rebuild = true;
+			afterBlock = false;
 			NonNullList<IIngredientListElement> ingredients = NonNullList.from(null, this.elementSearch.getAllIngredients().toArray(new IIngredientListElement[0]));
 			this.elementSearch = Config.isUltraLowMemoryMode() ? new ElementSearchLowMem() : new ElementSearch();
 			ingredients.sort(IngredientListElementComparator.INSTANCE);
 			this.elementSearch.addAll(ingredients);
+			// make sure search tree finishes building before gameplay resumes
+			if (this.elementSearch instanceof ElementSearch) {
+				((ElementSearch) this.elementSearch).block();
+			}
 			firstBuild = false;
 			rebuild = false;
 		}

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -77,8 +77,11 @@ public class IngredientListBatchRenderer {
 			}
 		}
 
-		refreshBuffer = true;
+		invalidateBuffer();
+	}
 
+	public void invalidateBuffer() {
+		refreshBuffer = true;
 	}
 
 	private <V> void set(IngredientListSlot ingredientListSlot, IIngredientListElement<V> element) {
@@ -178,6 +181,8 @@ public class IngredientListBatchRenderer {
 		if (!Config.isEditModeEnabled() && Config.bufferIngredientRenders() && refreshBuffer && OpenGlHelper.framebufferSupported) {
 			refreshBuffer = false;
 			minecraft.getFramebuffer().bindFramebuffer(false);
+			// ensure that we actually render the new items
+			render(minecraft);
 		}
 	}
 

--- a/src/main/java/mezz/jei/search/PrefixedSearchable.java
+++ b/src/main/java/mezz/jei/search/PrefixedSearchable.java
@@ -38,6 +38,8 @@ public class PrefixedSearchable implements ISearchable<IIngredientListElement<?>
 
     @Override
     public void submit(IIngredientListElement<?> ingredient) {
+        if(prefixInfo.getMode() == Config.SearchMode.DISABLED)
+            return;
         Collection<String> strings = prefixInfo.getStrings(ingredient);
         for (String string : strings) {
             searchStorage.put(string, ingredient);
@@ -46,6 +48,8 @@ public class PrefixedSearchable implements ISearchable<IIngredientListElement<?>
 
     @Override
     public void submitAll(NonNullList<IIngredientListElement> ingredients) {
+        if(prefixInfo.getMode() == Config.SearchMode.DISABLED)
+            return;
         if (IngredientFilter.firstBuild) {
             start();
             ProgressManager.ProgressBar progressBar = null;

--- a/src/main/java/mezz/jei/startup/ProxyCommonClient.java
+++ b/src/main/java/mezz/jei/startup/ProxyCommonClient.java
@@ -123,12 +123,13 @@ public class ProxyCommonClient extends ProxyCommon {
 			// check that HEI has been started before. if not, do nothing
 			if (this.starter.hasStarted()) {
 				if (Config.isDebugModeEnabled()) {
-					Log.get().info("Restarting HEI.", new RuntimeException("Stack trace for debugging"));
+					Log.get().info("Reloading HEI ingredient filter.", new RuntimeException("Stack trace for debugging"));
 				} else {
-					Log.get().info("Restarting HEI.");
+					Log.get().info("Reloading HEI ingredient filter.");
 				}
-				Preconditions.checkNotNull(textures);
-				this.starter.start(this.plugins, textures);
+				// force search tree to reload
+				Config.needToRebuildSearchTree = true;
+				reloadItemList();
 			}
 		});
 

--- a/src/main/java/mezz/jei/startup/ProxyCommonClient.java
+++ b/src/main/java/mezz/jei/startup/ProxyCommonClient.java
@@ -153,6 +153,7 @@ public class ProxyCommonClient extends ProxyCommon {
 		if (runtime != null) {
 			IngredientListOverlay ingredientListOverlay = runtime.getIngredientListOverlay();
 			ingredientListOverlay.rebuildItemFilter();
+			ingredientListOverlay.invalidateBuffer();
 		}
 	}
 


### PR DESCRIPTION
This PR depends on and should be merged after #57 (as it is based off that branch). Reloading resource packs now only rebuilds the search trees and invalidates the ingredient framebuffer, instead of completely restarting JEI.