### PR TITLE
Improve OptiFine compat for buffer ingredient renderers

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import mezz.jei.util.ReflectionUtil;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -58,8 +57,6 @@ public final class Config {
 	public static final int largestNumColumns = 100;
 	public static final int minRecipeGuiHeight = 175;
 	public static final int maxRecipeGuiHeight = 5000;
-
-	private static final boolean isOptifineInstalled = ReflectionUtil.isClassLoaded("optifine.OptiFineForgeTweaker");
 
 	@Nullable
 	private static LocalizedConfiguration config;

--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -11,15 +11,12 @@ import java.util.Locale;
 import java.util.Set;
 
 import mezz.jei.util.ReflectionUtil;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.settings.GameSettings;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.client.FMLClientHandler;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.ConfigCategory;
@@ -318,11 +315,7 @@ public final class Config {
 	}
 
 	public static boolean bufferIngredientRenders() {
-		boolean fastRender = false;
-		if (isOptifineInstalled) {
-			fastRender = ObfuscationReflectionHelper.getPrivateValue(GameSettings.class, Minecraft.getMinecraft().gameSettings, "ofFastRender");
-		}
-		return !fastRender && values.bufferIngredientRenders;
+		return values.bufferIngredientRenders;
 	}
 
 	public static boolean mouseClickToSeeRecipe() {

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -142,7 +142,7 @@ public class IngredientListBatchRenderer {
 	}
 
 	public void render(Minecraft minecraft) {
-		if (!Config.isEditModeEnabled() && Config.bufferIngredientRenders() && OpenGlHelper.framebufferSupported) {
+		if (!Config.isEditModeEnabled() && Config.bufferIngredientRenders() && OpenGlHelper.isFramebufferEnabled()) {
 			if (framebuffer == null) {
 				framebuffer = new Framebuffer(minecraft.displayWidth, minecraft.displayHeight, true);
 				framebuffer.framebufferColor[0] = 0.0F;


### PR DESCRIPTION
This PR:

- fixes ```Buffer Ingredient Renderers```' compatibility with OptiFine's Antialiasing option, which also disables framebuffers
- replaces reflection with ```OpenGlHelper.isFramebufferEnabled()```, potentially improving performance (this method respects antialiasing and fast render when OptiFine is installed)