### PR TITLE
Separated OrderedMultiMap from MultiMap

### DIFF
--- a/src/main/java/mezz/jei/collect/MultiMap.java
+++ b/src/main/java/mezz/jei/collect/MultiMap.java
@@ -1,6 +1,8 @@
 package mezz.jei.collect;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -9,83 +11,64 @@ import com.google.common.collect.ImmutableMultimap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 public class MultiMap<K, V, T extends Collection<V>> {
-	protected final Map<K, T> map;
-	private final List<K> keyOrder;
-	private final Function<K, T> collectionMappingFunction;
+    protected final Map<K, T> map;
+    protected final Function<K, T> collectionMappingFunction;
 
-	public MultiMap(Supplier<T> collectionSupplier) {
-		this(new Object2ObjectOpenHashMap<>(), collectionSupplier);
-	}
+    public MultiMap(Supplier<T> collectionSupplier) {
+        this(new Object2ObjectOpenHashMap<>(), collectionSupplier);
+    }
 
-	public MultiMap(Map<K, T> map, Supplier<T> collectionSupplier) {
-		this.map = map;
-		this.keyOrder = new ArrayList<>();
-		this.collectionMappingFunction = (k -> collectionSupplier.get());
-	}
+    public MultiMap(Map<K, T> map, Supplier<T> collectionSupplier) {
+        this.map = map;
+        this.collectionMappingFunction = (k -> collectionSupplier.get());
+    }
 
-	public void insertAt(int index, K key, T values) {
-		if (!map.containsKey(key)) {
-			map.put(key, values);
-			keyOrder.add(index, key);
-		}
-	}
+    public T get(K key) {
+        return map.computeIfAbsent(key, collectionMappingFunction);
+    }
 
-	public T get(K key) {
-		return map.computeIfAbsent(key, k -> {
-			keyOrder.add(k);
-			return collectionMappingFunction.apply(k);
-		});
-	}
+    public boolean put(K key, V value) {
+        return get(key).add(value);
+    }
 
-	public boolean put(K key, V value) {
-		return get(key).add(value);
-	}
+    public boolean remove(K key, V value) {
+        T collection = map.get(key);
+        return collection != null && collection.remove(value);
+    }
 
-	public boolean remove(K key, V value) {
-		T collection = map.get(key);
-		return collection != null && collection.remove(value);
-	}
+    public boolean containsKey(K key) {
+        return map.containsKey(key);
+    }
 
-	public void removeKey(K key) {
-		map.remove(key);
-	}
+    public boolean contains(K key, V value) {
+        T collection = map.get(key);
+        return collection != null && collection.contains(value);
+    }
 
-	public boolean containsKey(K key) {
-		return map.containsKey(key);
-	}
+    public Set<Map.Entry<K, T>> entrySet() {
+        return map.entrySet();
+    }
 
-	public boolean contains(K key, V value) {
-		T collection = map.get(key);
-		return collection != null && collection.contains(value);
-	}
+    public Stream<V> valueStream() {
+        return map.values().stream().flatMap(Collection::stream);
+    }
 
-	public List<Map.Entry<K, T>> entrySet() {
-		List<Map.Entry<K, T>> orderedEntries = new LinkedList<>();
-		for (K key : keyOrder) {
-			orderedEntries.add(new AbstractMap.SimpleEntry<>(key, map.get(key)));
-		}
-		return orderedEntries;
-	}
+    public int getTotalSize() {
+        int size = 0;
+        for (T value : map.values()) {
+            size += value.size();
+        }
+        return size;
+    }
 
-	public Stream<V> valueStream() {
-		return map.values().stream().flatMap(Collection::stream);
-	}
-
-	public int getTotalSize() {
-		int size = 0;
-		for (T value : map.values()) {
-			size += value.size();
-		}
-		return size;
-	}
-
-	public ImmutableMultimap<K, V> toImmutable() {
-		ImmutableMultimap.Builder<K, V> builder = ImmutableMultimap.builder();
-		for (K key : keyOrder) {
-			for (V value : map.get(key)) {
-				builder.put(key, value);
-			}
-		}
-		return builder.build();
-	}
+    public ImmutableMultimap<K, V> toImmutable() {
+        ImmutableMultimap.Builder<K, V> builder = ImmutableMultimap.builder();
+        for (Map.Entry<K, T> entry : map.entrySet()) {
+            K key = entry.getKey();
+            for (V value : entry.getValue()) {
+                builder.put(key, value);
+            }
+        }
+        return builder.build();
+    }
 }

--- a/src/main/java/mezz/jei/collect/OrderedListMultiMap.java
+++ b/src/main/java/mezz/jei/collect/OrderedListMultiMap.java
@@ -1,0 +1,20 @@
+package mezz.jei.collect;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class OrderedListMultiMap<K, V> extends OrderedMultiMap<K, V, List<V>> {
+    public OrderedListMultiMap() {
+        this(ArrayList::new);
+    }
+
+    public OrderedListMultiMap(Supplier<List<V>> collectionSupplier) {
+        super(collectionSupplier);
+    }
+
+    public OrderedListMultiMap(Map<K, List<V>> map, Supplier<List<V>> collectionSupplier) {
+        super(map, collectionSupplier);
+    }
+}

--- a/src/main/java/mezz/jei/collect/OrderedMultiMap.java
+++ b/src/main/java/mezz/jei/collect/OrderedMultiMap.java
@@ -1,0 +1,60 @@
+package mezz.jei.collect;
+
+import java.util.*;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableMultimap;
+
+public class OrderedMultiMap<K, V, T extends Collection<V>> extends MultiMap<K, V, T> {
+	private final List<K> keyOrder;
+
+	public OrderedMultiMap(Supplier<T> collectionSupplier) {
+		super(collectionSupplier);
+		this.keyOrder = new ArrayList<>();
+	}
+
+	public OrderedMultiMap(Map<K, T> map, Supplier<T> collectionSupplier) {
+		super(map, collectionSupplier);
+		this.keyOrder = new ArrayList<>();
+	}
+
+	public void insertAt(int index, K key, T values) {
+		if (!map.containsKey(key)) {
+			map.put(key, values);
+			keyOrder.add(index, key);
+		}
+	}
+
+	@Override
+	public T get(K key) {
+		return map.computeIfAbsent(key, k -> {
+			keyOrder.add(k);
+			return collectionMappingFunction.apply(k);
+		});
+	}
+
+	public void removeKey(K key) {
+		map.remove(key);
+		keyOrder.remove(key);
+	}
+
+	@Override
+	public Set<Map.Entry<K, T>> entrySet() {
+		Set<Map.Entry<K, T>> orderedEntries = new OrderedMultiSet<>();
+		for (K key : keyOrder) {
+			orderedEntries.add(new AbstractMap.SimpleEntry<>(key, map.get(key)));
+		}
+		return orderedEntries;
+	}
+
+	@Override
+	public ImmutableMultimap<K, V> toImmutable() {
+		ImmutableMultimap.Builder<K, V> builder = ImmutableMultimap.builder();
+		for (K key : keyOrder) {
+			for (V value : map.get(key)) {
+				builder.put(key, value);
+			}
+		}
+		return builder.build();
+	}
+}

--- a/src/main/java/mezz/jei/collect/OrderedMultiSet.java
+++ b/src/main/java/mezz/jei/collect/OrderedMultiSet.java
@@ -1,0 +1,27 @@
+package mezz.jei.collect;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+public class OrderedMultiSet<T> extends AbstractSet<T>
+{
+    private final List<T> list = new LinkedList<>();
+
+    @Override
+    public boolean add(T element) {
+        list.add(element);
+        return true;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return list.iterator();
+    }
+
+    @Override
+    public int size() {
+        return list.size();
+    }
+}

--- a/src/main/java/mezz/jei/recipes/RecipeRegistry.java
+++ b/src/main/java/mezz/jei/recipes/RecipeRegistry.java
@@ -14,6 +14,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import mezz.jei.collect.OrderedListMultiMap;
 import mezz.jei.config.Config;
 import net.minecraftforge.fml.common.ProgressManager;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -82,7 +83,7 @@ public class RecipeRegistry implements IRecipeRegistry {
 		List<Object> unsortedRecipes,
 		ListMultiMap<String, Object> recipes,
 		ListMultiMap<Class<? extends GuiContainer>, RecipeClickableArea> recipeClickableAreasMap,
-		ListMultiMap<String, Object> recipeCatalysts,
+		OrderedListMultiMap<String, Object> recipeCatalysts,
 		IngredientRegistry ingredientRegistry,
 		List<IRecipeRegistryPlugin> plugins
 	) {

--- a/src/main/java/mezz/jei/startup/ModRegistry.java
+++ b/src/main/java/mezz/jei/startup/ModRegistry.java
@@ -5,6 +5,7 @@ import java.util.stream.Stream;
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import mezz.jei.collect.OrderedListMultiMap;
 import mezz.jei.config.Config;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -64,7 +65,7 @@ public class ModRegistry implements IModRegistry, IRecipeCategoryRegistration {
 	private final ListMultiMap<String, Object> recipes = new ListMultiMap<>();
 	private final RecipeTransferRegistry recipeTransferRegistry;
 	private final ListMultiMap<Class<? extends GuiContainer>, RecipeClickableArea> recipeClickableAreas = new ListMultiMap<>();
-	private final ListMultiMap<String, Object> recipeCatalysts = new ListMultiMap<>();
+	private final OrderedListMultiMap<String, Object> recipeCatalysts = new OrderedListMultiMap<>();
 	private final List<IRecipeRegistryPlugin> recipeRegistryPlugins = new ArrayList<>();
 
 	public ModRegistry(JeiHelpers jeiHelpers, IIngredientRegistry ingredientRegistry) {


### PR DESCRIPTION
- added `OrderedMultiMap` which extends `MultiMap`
- added `OrderedMultiSet` for `OrderedMultiMap.entrySet`
- added `OrderedListMultiMap` which extends `OrderedMultiMap`
- `ListMultiMap<String, Object> recipeCatalysts` -> `OrderedListMultiMap<String, Object> recipeCatalysts`