### PR TITLE
Improved Item Stack Count Rendering with Custom Formatting and Scaling

### DIFF
--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
@@ -31,7 +31,13 @@ public class ItemStackRenderer implements IIngredientRenderer<ItemStack> {
 			minecraft.getRenderItem().renderItemAndEffectIntoGUI(ingredient, xPosition, yPosition);
 
 			if (ingredient.getCount() > 1) {
-				renderCustomStackSize(font, ingredient, xPosition, yPosition);
+				if (ingredient.getCount() < 65) {
+					ItemStack overlayStack = ingredient.copy();
+					overlayStack.setCount(ingredient.getCount());
+					minecraft.getRenderItem().renderItemOverlayIntoGUI(font, overlayStack, xPosition, yPosition, null);
+				} else {
+					renderCustomStackSize(font, ingredient, xPosition, yPosition);
+				}
 			} else {
 				ItemStack overlayStack = ingredient.copy();
 				overlayStack.setCount(1);
@@ -100,10 +106,9 @@ public class ItemStackRenderer implements IIngredientRenderer<ItemStack> {
 			return String.format(m % 1 == 0 ? "%.0fm" : "%.1fm", m);
 		}
 
-        float g = count / 1000000000f;
-        return String.format(g % 1 == 0 ? "%.0fg" : "%.1fg", g);
-
-    }
+		float g = count / 1000000000f;
+		return String.format(g % 1 == 0 ? "%.0fg" : "%.1fg", g);
+	}
 
 	@Override
 	public List<String> getTooltip(Minecraft minecraft, ItemStack ingredient, ITooltipFlag tooltipFlag) {

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
@@ -29,11 +29,72 @@ public class ItemStackRenderer implements IIngredientRenderer<ItemStack> {
 			RenderHelper.enableGUIStandardItemLighting();
 			FontRenderer font = getFontRenderer(minecraft, ingredient);
 			minecraft.getRenderItem().renderItemAndEffectIntoGUI(null, ingredient, xPosition, yPosition);
-			minecraft.getRenderItem().renderItemOverlayIntoGUI(font, ingredient, xPosition, yPosition, null);
+			renderCustomStackSize(font, ingredient, xPosition, yPosition);
 			GlStateManager.disableBlend();
 			RenderHelper.disableStandardItemLighting();
 		}
 	}
+
+	/**
+	 * Custom method for rendering item stack count
+	 * @param font The font renderer
+	 * @param stack The item stack
+	 * @param xPosition X coordinate
+	 * @param yPosition Y coordinate
+	 */
+	private void renderCustomStackSize(FontRenderer font, ItemStack stack, int xPosition, int yPosition) {
+		if (stack.getCount() != 1) {
+			String countText = formatStackCount(stack.getCount());
+			GlStateManager.disableLighting();
+			GlStateManager.disableDepth();
+			GlStateManager.disableBlend();
+			boolean shouldScale = stack.getCount() > 99;
+			if (shouldScale) {
+				GlStateManager.pushMatrix();
+				GlStateManager.scale(0.5F, 0.5F, 1.0F);
+			}
+			int x = shouldScale ?
+					(xPosition + 16) * 2 - font.getStringWidth(countText) :
+					xPosition + 16 - font.getStringWidth(countText);
+			int y = shouldScale ?
+					(yPosition + 16) * 2 - 8 :
+					yPosition + 16 - 8;
+			font.drawStringWithShadow(countText, x, y, 0xFFFFFF);
+			if (shouldScale) {
+				GlStateManager.popMatrix();
+			}
+			GlStateManager.enableLighting();
+			GlStateManager.enableDepth();
+			GlStateManager.enableBlend();
+		}
+	}
+
+	/**
+	 * Formats the stack count for display
+	 */
+	private String formatStackCount(int count) {
+		if (count <= 99) {
+			return String.valueOf(count);
+		}
+
+		if (count <= 9999) {
+			return String.valueOf(count);
+		}
+
+		if (count <= 999999) {
+			float k = count / 1000f;
+			return String.format(k % 1 == 0 ? "%.0fk" : "%.1fk", k);
+		}
+
+		if (count <= 999999999) {
+			float m = count / 1000000f;
+			return String.format(m % 1 == 0 ? "%.0fm" : "%.1fm", m);
+		}
+
+        float g = count / 1000000000f;
+        return String.format(g % 1 == 0 ? "%.0fg" : "%.1fg", g);
+
+    }
 
 	@Override
 	public List<String> getTooltip(Minecraft minecraft, ItemStack ingredient, ITooltipFlag tooltipFlag) {

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
@@ -28,8 +28,15 @@ public class ItemStackRenderer implements IIngredientRenderer<ItemStack> {
 			GlStateManager.enableDepth();
 			RenderHelper.enableGUIStandardItemLighting();
 			FontRenderer font = getFontRenderer(minecraft, ingredient);
-			minecraft.getRenderItem().renderItemAndEffectIntoGUI(null, ingredient, xPosition, yPosition);
-			renderCustomStackSize(font, ingredient, xPosition, yPosition);
+			minecraft.getRenderItem().renderItemAndEffectIntoGUI(ingredient, xPosition, yPosition);
+			ItemStack durabilityOnlyStack = ingredient.copy();
+			durabilityOnlyStack.setCount(1);
+			minecraft.getRenderItem().renderItemOverlayIntoGUI(font, durabilityOnlyStack, xPosition, yPosition, null);
+
+			if (ingredient.getCount() != 1) {
+				renderCustomStackSize(font, ingredient, xPosition, yPosition);
+			}
+
 			GlStateManager.disableBlend();
 			RenderHelper.disableStandardItemLighting();
 		}

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
@@ -29,12 +29,13 @@ public class ItemStackRenderer implements IIngredientRenderer<ItemStack> {
 			RenderHelper.enableGUIStandardItemLighting();
 			FontRenderer font = getFontRenderer(minecraft, ingredient);
 			minecraft.getRenderItem().renderItemAndEffectIntoGUI(ingredient, xPosition, yPosition);
-			ItemStack durabilityOnlyStack = ingredient.copy();
-			durabilityOnlyStack.setCount(1);
-			minecraft.getRenderItem().renderItemOverlayIntoGUI(font, durabilityOnlyStack, xPosition, yPosition, null);
 
-			if (ingredient.getCount() != 1) {
+			if (ingredient.getCount() > 1) {
 				renderCustomStackSize(font, ingredient, xPosition, yPosition);
+			} else {
+				ItemStack overlayStack = ingredient.copy();
+				overlayStack.setCount(1);
+				minecraft.getRenderItem().renderItemOverlayIntoGUI(font, overlayStack, xPosition, yPosition, null);
 			}
 
 			GlStateManager.disableBlend();
@@ -50,30 +51,31 @@ public class ItemStackRenderer implements IIngredientRenderer<ItemStack> {
 	 * @param yPosition Y coordinate
 	 */
 	private void renderCustomStackSize(FontRenderer font, ItemStack stack, int xPosition, int yPosition) {
-		if (stack.getCount() != 1) {
-			String countText = formatStackCount(stack.getCount());
-			GlStateManager.disableLighting();
-			GlStateManager.disableDepth();
-			GlStateManager.disableBlend();
-			boolean shouldScale = stack.getCount() > 99;
-			if (shouldScale) {
-				GlStateManager.pushMatrix();
-				GlStateManager.scale(0.5F, 0.5F, 1.0F);
-			}
-			int x = shouldScale ?
-					(xPosition + 16) * 2 - font.getStringWidth(countText) :
-					xPosition + 16 - font.getStringWidth(countText);
-			int y = shouldScale ?
-					(yPosition + 16) * 2 - 8 :
-					yPosition + 16 - 8;
-			font.drawStringWithShadow(countText, x, y, 0xFFFFFF);
-			if (shouldScale) {
-				GlStateManager.popMatrix();
-			}
-			GlStateManager.enableLighting();
-			GlStateManager.enableDepth();
-			GlStateManager.enableBlend();
+		String countText = formatStackCount(stack.getCount());
+
+		GlStateManager.pushMatrix();
+		GlStateManager.disableLighting();
+		GlStateManager.disableDepth();
+		GlStateManager.disableBlend();
+
+		boolean shouldScale = stack.getCount() > 99;
+		if (shouldScale) {
+			GlStateManager.scale(0.5F, 0.5F, 1.0F);
 		}
+
+		int x = shouldScale ?
+				(xPosition + 16) * 2 - font.getStringWidth(countText) :
+				xPosition + 16 - font.getStringWidth(countText);
+		int y = shouldScale ?
+				(yPosition + 16) * 2 - 8 :
+				yPosition + 16 - 8;
+
+		font.drawStringWithShadow(countText, x, y, 0xFFFFFF);
+
+		GlStateManager.popMatrix();
+		GlStateManager.enableLighting();
+		GlStateManager.enableDepth();
+		GlStateManager.enableBlend();
 	}
 
 	/**


### PR DESCRIPTION
This PR enhances the item stack count rendering in JEI with the following improvements:

Custom Stack Size Rendering

Extracted stack count rendering into a dedicated renderCustomStackSize method for better organization

Added dynamic scaling for large stack counts (>99) to improve readability

Properly manages GL state (lighting, depth, blend) during rendering

Intelligent Count Formatting

Implemented a new formatStackCount method that formats stack counts in a more readable way:

Shows exact numbers for counts ≤9999

Displays "k" suffix for thousands (10k-999k)

Displays "m" suffix for millions (1m-999m)

Displays "g" suffix for billions (1g+)

Maintains precision by showing decimal places only when needed

Improved Visual Alignment

Adjusted positioning logic to ensure properly aligned text for both normal and scaled counts

Uses shadowed text for better visibility against various backgrounds

These changes make large item stack counts more readable while maintaining clean visuals. 