### PR TITLE
Fix Alignment of Counts in Custom Renderer

### DIFF
--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackRenderer.java
@@ -71,10 +71,10 @@ public class ItemStackRenderer implements IIngredientRenderer<ItemStack> {
 
 		int x = shouldScale ?
 				(xPosition + 16) * 2 - font.getStringWidth(countText) :
-				xPosition + 16 - font.getStringWidth(countText);
+				xPosition + 17 - font.getStringWidth(countText);
 		int y = shouldScale ?
 				(yPosition + 16) * 2 - 8 :
-				yPosition + 16 - 8;
+				yPosition + 17 - 8;
 
 		font.drawStringWithShadow(countText, x, y, 0xFFFFFF);
 


### PR DESCRIPTION
This PR fixes the large size counts (< 100) in the custom renderer not being aligned with the vanilla renderer, causing weird graphics when side by side.

The small size counts' positions have not been modified, as small text, without shadow, going across slot borders is hard to read.

Before:
<img width="375" alt="image" src="https://github.com/user-attachments/assets/9b41a3c4-e39e-45ca-bee0-8190736b66bf" />

After:
<img width="375" alt="image" src="https://github.com/user-attachments/assets/9c6fedb4-3e99-4d83-be7f-74da28468327" />
