### PR TITLE
Change Default Start to Recipe Only False

### DIFF
--- a/src/main/java/mezz/jei/startup/JeiStarter.java
+++ b/src/main/java/mezz/jei/startup/JeiStarter.java
@@ -40,7 +40,7 @@ public class JeiStarter {
 	private boolean started;
 
 	public void start(List<IModPlugin> plugins, Textures textures) {
-		load(plugins, textures, true);
+		load(plugins, textures, false);
 	}
 
 	public void load(List<IModPlugin> plugins, Textures textures, boolean recipesOnly) {


### PR DESCRIPTION
This PR fixes a typo in https://github.com/CleanroomMC/HadEnoughItems/commit/c3fea788a2950ed36feb20f97c8afaf4a60a2725, where the default mode for starting JEI would be in 'recipeOnly' mode. This is irrelevant for normal operation, and only breaks GroovyScript reload in the case where ingredients are modified.

Yes, I caved in and made the one line PR.