### PR TITLE
Fix Search Bar Not Giving Up Focus

### DIFF
--- a/src/main/java/mezz/jei/gui/ghost/GhostIngredientDragManager.java
+++ b/src/main/java/mezz/jei/gui/ghost/GhostIngredientDragManager.java
@@ -154,8 +154,11 @@ public class GhostIngredientDragManager {
 
     public boolean handleKeyDown(int eventKey) {
         if (KeyBindings.isInventoryCloseKey(eventKey) || KeyBindings.isEnterKey(eventKey)) {
-            stopDrag();
-            return true;
+            // Only cancel other handling of inputs if we are currently dragging
+            if (this.ghostIngredientDrag != null) {
+                stopDrag();
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
This PR fixes the ghost ingredient drag cancellation consuming all `enter` and `escape` key inputs, preventing those to be used to exit search bar focus. The consuming of these keybinds now only occurs if dragging is ongoing.

Fixes https://github.com/CleanroomMC/HadEnoughItems/issues/148.