### PR TITLE
Stop Craftable Ingredients Map Transferring State Across HEI Loads

### DIFF
--- a/src/main/java/mezz/jei/startup/ModIngredientRegistration.java
+++ b/src/main/java/mezz/jei/startup/ModIngredientRegistration.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 public class ModIngredientRegistration implements IModIngredientRegistration {
 	private final Map<IIngredientType, Collection> allIngredientsMap = new Reference2ObjectOpenHashMap<>();
-	public static final List<IIngredientType> CRAFTABLE_INGREDIENTS = new ObjectArrayList<>();
+	private final List<IIngredientType> craftableIngredientsMap = new ObjectArrayList<>();
 	private final Map<IIngredientType, IIngredientHelper> ingredientHelperMap = new Reference2ObjectOpenHashMap<>();
 	private final Map<IIngredientType, IIngredientRenderer> ingredientRendererMap = new Reference2ObjectOpenHashMap<>();
 
@@ -37,7 +37,7 @@ public class ModIngredientRegistration implements IModIngredientRegistration {
 
 	@Override
 	public <V> void markAsCraftable(IIngredientType<V> ingredientType) {
-		CRAFTABLE_INGREDIENTS.add(ingredientType);
+		craftableIngredientsMap.add(ingredientType);
 	}
 
 	@Override
@@ -62,7 +62,7 @@ public class ModIngredientRegistration implements IModIngredientRegistration {
 			ingredientsMap,
 			ImmutableMap.copyOf(ingredientHelperMap),
 			ImmutableMap.copyOf(ingredientRendererMap),
-			ImmutableList.copyOf(CRAFTABLE_INGREDIENTS)
+			ImmutableList.copyOf(craftableIngredientsMap)
 		);
 	}
 


### PR DESCRIPTION
This PR fixes the new craftable ingredients map transferring state between HEI laods, due to it being static. This PR changes it to be private and instance-level (which may break mods who updated to directly access the map for some reason, which shouldn't be allowed regardless).

Note that all other fields in `ModIngredientRegistration` apart from this new field is private and instance-level; as are fields in other HEI loading state classes.

This fixes GroovyScript's JEI reload causing recipe bookmarks to break, as it would cause the craftable ingredients map to grow in size thus resulting in a change to recipe hashes, which use a loop over craftable ingredients.