### PR TITLE
Allow Using Keypad Enter to Give Up Focus

### DIFF
--- a/src/main/java/mezz/jei/config/KeyBindings.java
+++ b/src/main/java/mezz/jei/config/KeyBindings.java
@@ -62,6 +62,6 @@ public final class KeyBindings {
 	}
 
 	public static boolean isEnterKey(int keyCode) {
-		return keyCode == Keyboard.KEY_RETURN;
+		return keyCode == Keyboard.KEY_RETURN || keyCode == Keyboard.KEY_NUMPADENTER;
 	}
 }


### PR DESCRIPTION
This PR allows the keypad enter key to serve the same functions as the return key in HEI's handling. This includes giving up focus of the search bar.

Reported and fix tested by @Exaxxion.