### PR TITLE
Fix infinite loop in BookmarkListBatchRenderer.sizePages() when there's no space …

### DIFF
--- a/src/main/java/mezz/jei/render/BookmarkListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/BookmarkListBatchRenderer.java
@@ -79,6 +79,7 @@ public class BookmarkListBatchRenderer extends IngredientListBatchRenderer {
         int ingredientIndex = 0;
         int currentGroup = ingredientList.get(ingredientIndex).getGroupIndex();
         while (true) {
+            int previousIngredientIndex = ingredientIndex;
             for (int rowIndex = 0; rowIndex < slots.size(); rowIndex++) {
                 List<IngredientListSlot> row = slots.get(rowIndex);
                 for (int column = 0; column < row.size(); column++) {
@@ -98,6 +99,7 @@ public class BookmarkListBatchRenderer extends IngredientListBatchRenderer {
                     }
                 }
             }
+            if(ingredientIndex == previousIngredientIndex) return pages;
             pages.add(ingredientIndex);
         }
     }


### PR DESCRIPTION
…for any items

Closes https://github.com/Nomi-CEu/Nomi-CEu/issues/1519

This PR essentially adds deadlock detection by storing previous progress from the method. If it is found that iteration of the outermost loop has not added any slots, is is known that further iterations will not fit any more since the item index is the same.