### PR TITLE
Add ability to reorder bookmark groups, hotkey for adding recipes to bookmarks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs = -Xmx3G
 
 # Source Options
 # Use Modern Java(9+) Syntax (Courtesy of Jabel)
-use_modern_java_syntax = true
+use_modern_java_syntax = false
 # Spotless automatically refactors your project from java code to jsons for a tidied, uniformed look
 spotless = false
 # Spotless Options

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs = -Xmx3G
 
 # Source Options
 # Use Modern Java(9+) Syntax (Courtesy of Jabel)
-use_modern_java_syntax = false
+use_modern_java_syntax = true
 # Spotless automatically refactors your project from java code to jsons for a tidied, uniformed look
 spotless = false
 # Spotless Options

--- a/src/main/java/mezz/jei/autocrafting/RecipeBookmarkGroup.java
+++ b/src/main/java/mezz/jei/autocrafting/RecipeBookmarkGroup.java
@@ -32,6 +32,16 @@ public class RecipeBookmarkGroup extends BookmarkGroup {
         }
         return false;
     }
+    
+    public boolean addItem(BookmarkItem<?> item, boolean toFront) {
+        if (super.addItem(item, toFront)) {
+            chain.addOutput((RecipeBookmarkItem<?>) item); // From canAddItem
+            
+            return true;
+        }
+
+        return false;
+    }
 
     public boolean canAddItem(BookmarkItem<?> item) {
         return item instanceof RecipeBookmarkItem;

--- a/src/main/java/mezz/jei/bookmarks/BookmarkList.java
+++ b/src/main/java/mezz/jei/bookmarks/BookmarkList.java
@@ -324,4 +324,12 @@ public class BookmarkList implements IIngredientGridSource {
         }
         return false;
     }
+
+    public void swapGroups(int first, int second) {
+        int firstIndex = getBookmarkIndex(first);
+        int secondIndex = getBookmarkIndex(second);
+        Collections.swap(list, firstIndex, secondIndex);
+        notifyListenersOfChange();
+        saveBookmarks();
+    }
 }

--- a/src/main/java/mezz/jei/config/KeyBindings.java
+++ b/src/main/java/mezz/jei/config/KeyBindings.java
@@ -23,6 +23,8 @@ public final class KeyBindings {
 	public static final KeyBinding previousPage;
 	public static final KeyBinding nextPage;
 	public static final KeyBinding bookmark;
+	public static final KeyBinding bookmarkToTop;
+	public static final KeyBinding recipeBookmark;
 	public static final KeyBinding toggleBookmarkOverlay;
 	public static final KeyBinding crafting;
 	private static final List<KeyBinding> allBindings;
@@ -39,6 +41,8 @@ public final class KeyBindings {
 			previousPage = new KeyBinding("key.jei.previousPage", KeyConflictContext.GUI, Keyboard.KEY_PRIOR, categoryName),
 			nextPage = new KeyBinding("key.jei.nextPage", KeyConflictContext.GUI, Keyboard.KEY_NEXT, categoryName),
 			bookmark = new KeyBinding("key.jei.bookmark", KeyConflictContext.GUI, KeyModifier.NONE, Keyboard.KEY_A, categoryName),
+			bookmarkToTop = new KeyBinding("key.hei.bookmarkToTop", KeyConflictContext.GUI, KeyModifier.SHIFT, Keyboard.KEY_A, categoryName),
+			recipeBookmark = new KeyBinding("key.hei.recipeBookmark", KeyConflictContext.GUI, KeyModifier.CONTROL, Keyboard.KEY_A, categoryName),
 			toggleBookmarkOverlay = new KeyBinding("key.hei.toggleBookmarkOverlay", KeyConflictContext.GUI, Keyboard.KEY_NONE, categoryName),
 			crafting = new KeyBinding("key.hei.crafting", KeyConflictContext.GUI, KeyModifier.SHIFT, Keyboard.KEY_C, categoryName)
 		);

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGridWithNavigation.java
@@ -123,9 +123,16 @@ public class BookmarkGridWithNavigation implements IShowsRecipeFocuses, IMouseHa
 
     @Override
     public boolean handleMouseClicked(int mouseX, int mouseY, int mouseButton) {
-        return !guiScreenHelper.isInGuiExclusionArea(mouseX, mouseY) &&
-                (this.bookmarkGrid.handleMouseClicked(mouseX, mouseY) || this.navigation.handleMouseClickedButtons(mouseX, mouseY));
+        return !guiScreenHelper.isInGuiExclusionArea(mouseX, mouseY)
+            && (this.groupOrganizer.handleMouseClicked(mouseX, mouseY, mouseButton)
+                || this.bookmarkGrid.handleMouseClicked(mouseX, mouseY)
+                || this.navigation.handleMouseClickedButtons(mouseX, mouseY));
 
+    }
+
+    // TODO: Add to interface?
+    public boolean handleMouseReleased(int mouseX, int mouseY, int mouseButton) {
+        return this.groupOrganizer.handleMouseReleased(mouseX, mouseY, mouseButton);
     }
 
     @Override

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
@@ -186,6 +186,15 @@ public class BookmarkOverlay implements ILeftAreaContent, IBookmarkOverlay {
 	}
 
 	@Override
+	public boolean handleMouseReleased(int mouseX, int mouseY, int mouseButton) {
+		if (contents.isMouseOver(mouseX, mouseY)) {
+			return this.contents.handleMouseReleased(mouseX, mouseY, mouseButton);
+		}
+
+		return false;
+	}
+	
+	@Override
 	public boolean onKeyPressed(char typedChar, int eventKey) {
 		return isListDisplayed() && this.contents.getBookmarkGroupOrganizer().onKeyPressed(typedChar, eventKey);
 	}

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/ILeftAreaContent.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/ILeftAreaContent.java
@@ -22,5 +22,7 @@ public interface ILeftAreaContent extends IShowsRecipeFocuses, IGhostIngredientD
 
 	boolean handleMouseClicked(int mouseX, int mouseY, int mouseButton);
 
+	boolean handleMouseReleased(int mouseX, int mouseY, int mouseButton);
+
     boolean onKeyPressed(char typedChar, int eventKey);
 }

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/LeftAreaDispatcher.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/LeftAreaDispatcher.java
@@ -150,6 +150,18 @@ public class LeftAreaDispatcher implements IShowsRecipeFocuses, IGhostIngredient
 		return false;
 	}
 
+	public boolean handleMouseReleased(int mouseX, int mouseY, int mouseButton) {
+		if (!(canShow || hasContent())) {
+			return false;
+		}	
+
+		if (displayArea.contains(mouseX, mouseY)) {
+			return contents.get(current).handleMouseReleased(mouseX, mouseY, mouseButton);
+		}
+
+		return false;
+	}
+
 	@Override
 	public boolean nextPage() {
 		current++;

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupDisplay.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupDisplay.java
@@ -24,9 +24,13 @@ public class BookmarkGroupDisplay implements IGhostIngredientHandler.Target {
 
     @Override
     public void accept(Object ingredient) {
+        accept(ingredient, false); 
+    }
+
+    public void accept(Object ingredient, boolean toFront) {
         if (ingredient instanceof BookmarkItem) {
             BookmarkGroup oldGroup = ((BookmarkItem<?>) ingredient).getGroup();
-            boolean canAdd = group.addItem((BookmarkItem<?>) ingredient);
+            boolean canAdd = group.addItem((BookmarkItem<?>) ingredient, toFront);
             if (canAdd) {
                 if (oldGroup != null) {
                     oldGroup.removeItem((BookmarkItem<?>) ingredient);
@@ -36,7 +40,7 @@ public class BookmarkGroupDisplay implements IGhostIngredientHandler.Target {
             }
         } else {
             BookmarkItem<?> item = new BookmarkItem<>(ingredient);
-            if (group.addItem(item)) {
+            if (group.addItem(item, toFront)) {
                 if (!Config.isBookmarkOverlayEnabled())
                     Config.toggleBookmarkEnabled();
                 Internal.getBookmarkList().saveBookmarks();

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupOrganizer.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupOrganizer.java
@@ -6,6 +6,7 @@ import mezz.jei.api.gui.IGhostIngredientHandler;
 import mezz.jei.autocrafting.RecipeBookmarkGroup;
 import mezz.jei.autocrafting.RecipeBookmarkItem;
 import mezz.jei.bookmarks.BookmarkGroup;
+import mezz.jei.bookmarks.BookmarkItem;
 import mezz.jei.bookmarks.BookmarkList;
 import mezz.jei.config.Config;
 import mezz.jei.config.KeyBindings;
@@ -279,15 +280,52 @@ public class BookmarkGroupOrganizer {
     private void handleGroupDrag(int mouseX, int mouseY) {
         if (dragWholeGroup) {
             int currentGroupId = getGroupForSwap(mouseX, mouseY);
-            if (currentGroupId != -1 && currentGroupId != draggedGroupId) {
-                BookmarkGroupDisplay currentGroup = groups.get(currentGroupId);
-                BookmarkGroupDisplay draggedGroup = groups.get(draggedGroupId);
-                Internal.getBookmarkList().swapGroups(currentGroup.group.id, draggedGroup.group.id);
-
-                draggedGroupId = currentGroupId;
+            if (currentGroupId == -1 || currentGroupId == draggedGroupId) {
+                return;
             }
+
+            BookmarkGroupDisplay currentGroup = groups.get(currentGroupId);
+            BookmarkGroupDisplay draggedGroup = groups.get(draggedGroupId);
+            Internal.getBookmarkList().swapGroups(currentGroup.group.id, draggedGroup.group.id);
+
+            draggedGroupId = currentGroupId;
         } else {
-            // TODO: Expand group by dragging
+            if (groups.size() < 2) {
+                return;
+            }
+
+            int currentGroupId = getGroupIndexAt(mouseX, mouseY);
+            if (currentGroupId == -1 || currentGroupId == draggedGroupId) {
+                return;
+            }
+
+            // only allow groups next to each other to be merged
+            int groupDiff = currentGroupId - draggedGroupId;
+            if (groupDiff > 1 || groupDiff < -1) {
+                return;
+            }
+
+            int deltaY = mouseY - prevMouseY;
+            if (deltaY == 0) {
+                return;
+            }
+ 
+            int sig = Integer.signum(deltaY);
+            BookmarkGroupDisplay currentGroup = groups.get(currentGroupId);                
+            List<BookmarkItem<?>> bookmarks = currentGroup.group.getItems();
+            BookmarkItem<?> itemToMerge = null;
+            for (int idx = sig > 0 ? 0 : bookmarks.size() - 1; idx != -1 && idx < bookmarks.size(); idx += sig) {
+                BookmarkItem<?> candidate = bookmarks.get(idx);
+                if (candidate instanceof RecipeBookmarkItem<?>) {
+                    itemToMerge = candidate;
+                    break;
+                }
+            }
+
+            if (itemToMerge != null) {
+                BookmarkGroupDisplay draggedGroup = groups.get(draggedGroupId);
+                draggedGroup.accept(itemToMerge, sig < 0);
+            }            
         }
     }
 

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupOrganizer.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupOrganizer.java
@@ -290,42 +290,8 @@ public class BookmarkGroupOrganizer {
 
             draggedGroupId = currentGroupId;
         } else {
-            if (groups.size() < 2) {
-                return;
-            }
-
-            int currentGroupId = getGroupIndexAt(mouseX, mouseY);
-            if (currentGroupId == -1 || currentGroupId == draggedGroupId) {
-                return;
-            }
-
-            // only allow groups next to each other to be merged
-            int groupDiff = currentGroupId - draggedGroupId;
-            if (groupDiff > 1 || groupDiff < -1) {
-                return;
-            }
-
-            int deltaY = mouseY - prevMouseY;
-            if (deltaY == 0) {
-                return;
-            }
- 
-            int sig = Integer.signum(deltaY);
-            BookmarkGroupDisplay currentGroup = groups.get(currentGroupId);                
-            List<BookmarkItem<?>> bookmarks = currentGroup.group.getItems();
-            BookmarkItem<?> itemToMerge = null;
-            for (int idx = sig > 0 ? 0 : bookmarks.size() - 1; idx != -1 && idx < bookmarks.size(); idx += sig) {
-                BookmarkItem<?> candidate = bookmarks.get(idx);
-                if (candidate instanceof RecipeBookmarkItem<?>) {
-                    itemToMerge = candidate;
-                    break;
-                }
-            }
-
-            if (itemToMerge != null) {
-                BookmarkGroupDisplay draggedGroup = groups.get(draggedGroupId);
-                draggedGroup.accept(itemToMerge, sig < 0);
-            }            
+            // TODO: Handle group extension by dragging. 
+            // For partial/broken implementation refer to commit 529ee9599efd1f2e964106ec32da364b88b7e13f
         }
     }
 

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupOrganizer.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupOrganizer.java
@@ -37,6 +37,9 @@ public class BookmarkGroupOrganizer {
     private Rectangle area = new Rectangle();
     private int hoveredGroupId = -1;
     private int missingIngredients = 0;
+    private int draggedGroupId = -1;
+    private boolean dragWholeGroup = false;
+    private int prevMouseY = 0;
 
     public BookmarkGroupOrganizer() {
     }
@@ -124,7 +127,13 @@ public class BookmarkGroupOrganizer {
         }
         if (mouseX > area.x + BookmarkGridWithNavigation.BOOKMARK_TAB_WIDTH) {
             hoveredGroupId = -1;
+            stopDrag();
             return;
+        }
+
+        if (draggedGroupId != -1) {
+            handleGroupDrag(mouseX, mouseY);
+            prevMouseY = mouseY;
         }
 
         boolean hovered = false;
@@ -224,6 +233,92 @@ public class BookmarkGroupOrganizer {
                 }
             }
         }
+
+        if (KeyBindings.isInventoryCloseKey(eventKey) || KeyBindings.isInventoryToggleKey(eventKey)) {
+            stopDrag();
+        }
+
         return false;
+    }
+
+    public boolean handleMouseClicked(int mouseX, int mouseY, int mouseButton) {
+        if (mouseX > area.x + BookmarkGridWithNavigation.BOOKMARK_TAB_WIDTH) {
+            return false;
+        }
+
+        if (draggedGroupId != -1 || mouseButton != 0 || !area.contains(mouseX, mouseY)) {
+            return false;
+        }
+
+        int groupId = getGroupIndexAt(mouseX, mouseY);
+        if (groupId != -1) {
+            draggedGroupId = groupId;
+            dragWholeGroup = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)
+                || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
+ 
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean handleMouseReleased(int mouseX, int mouseY, int mouseButton) {
+        if (mouseButton != 0 || draggedGroupId == -1) {
+            return false;
+        }
+
+        stopDrag();
+        return true;
+    }
+
+    private void stopDrag() {
+        draggedGroupId = -1;
+        dragWholeGroup = false;
+    }
+
+    private void handleGroupDrag(int mouseX, int mouseY) {
+        if (dragWholeGroup) {
+            int currentGroupId = getGroupForSwap(mouseX, mouseY);
+            if (currentGroupId != -1 && currentGroupId != draggedGroupId) {
+                BookmarkGroupDisplay currentGroup = groups.get(currentGroupId);
+                BookmarkGroupDisplay draggedGroup = groups.get(draggedGroupId);
+                Internal.getBookmarkList().swapGroups(currentGroup.group.id, draggedGroup.group.id);
+
+                draggedGroupId = currentGroupId;
+            }
+        } else {
+            // TODO: Expand group by dragging
+        }
+    }
+
+    private int getGroupIndexAt(int mouseX, int mouseY) {
+        for (int i = 0; i < groups.size(); ++i) {
+            BookmarkGroupDisplay group = groups.get(i);
+            if (group.area.contains(mouseX, mouseY)) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private int getGroupForSwap(int mouseX, int mouseY) {
+        int mouseDeltaY = mouseY - prevMouseY;
+        if (mouseDeltaY == 0) {
+            return -1;
+        }
+
+        int sig = Integer.signum(mouseDeltaY);
+        int candidateId = getGroupIndexAt(mouseX, mouseY);
+        if (candidateId == -1) {
+            return -1;
+        }
+        
+        BookmarkGroupDisplay candidate = groups.get(candidateId);
+        if (!candidate.area.contains(mouseX, mouseY + sig * INGREDIENT_HEIGHT)) {
+            return candidateId;
+        }
+
+        return -1;
     }
 }

--- a/src/main/java/mezz/jei/gui/recipes/RecipeBookmarkButton.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeBookmarkButton.java
@@ -52,13 +52,7 @@ public class RecipeBookmarkButton extends GuiIconButtonSmall {
         if (!Config.isBookmarkOverlayEnabled()) {
             Config.toggleBookmarkEnabled();
         }
-        BookmarkList bookmarkList = Internal.getBookmarkList();
-        RecipeBookmarkGroup group = new RecipeBookmarkGroup(bookmarkList.nextId());
-        RecipeBookmarkItem<?> recipeBookmarkItem = new RecipeBookmarkItem<>(recipeLayout.getRecipeFavoriteButton().getDisplayedIngredient());
-        recipeBookmarkItem.setGroup(group); // Do this early so that the dummy items are also added.
-        recipeBookmarkItem.populateWith(recipe, category);
-        group.addItem(recipeBookmarkItem); // Do this late so that the recipe isn't overwritten.
-        group.update();
-        return bookmarkList.add(group);
+       
+        return recipeLayout.addToBookmarks();
     }
 }

--- a/src/main/java/mezz/jei/gui/recipes/RecipeLayout.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeLayout.java
@@ -1,5 +1,13 @@
 package mezz.jei.gui.recipes;
 
+import java.awt.Color;
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
 import it.unimi.dsi.fastutil.objects.Reference2ObjectArrayMap;
 import mezz.jei.Internal;
 import mezz.jei.api.gui.IDrawable;
@@ -13,6 +21,9 @@ import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IIngredientType;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeWrapper;
+import mezz.jei.autocrafting.RecipeBookmarkGroup;
+import mezz.jei.autocrafting.RecipeBookmarkItem;
+import mezz.jei.bookmarks.BookmarkList;
 import mezz.jei.gui.Focus;
 import mezz.jei.gui.TooltipRenderer;
 import mezz.jei.gui.elements.DrawableNineSliceTexture;
@@ -28,12 +39,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
-
-import javax.annotation.Nullable;
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 public class RecipeLayout implements IRecipeLayoutDrawable {
 	private static final int RECIPE_BUTTON_SIZE = 13;
@@ -412,5 +417,14 @@ public class RecipeLayout implements IRecipeLayoutDrawable {
 		return posY;
 	}
 
-
+	public boolean addToBookmarks() {
+        BookmarkList bookmarkList = Internal.getBookmarkList();
+        RecipeBookmarkGroup group = new RecipeBookmarkGroup(bookmarkList.nextId());
+        RecipeBookmarkItem<?> recipeBookmarkItem = new RecipeBookmarkItem<>(getRecipeFavoriteButton().getDisplayedIngredient());
+        recipeBookmarkItem.setGroup(group); // Do this early so that the dummy items are also added.
+        recipeBookmarkItem.populateWith(recipeWrapper, recipeCategory);
+        group.addItem(recipeBookmarkItem); // Do this late so that the recipe isn't overwritten.
+        group.update();
+        return bookmarkList.add(group);
+	}
 }

--- a/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -557,4 +557,15 @@ public class RecipesGui extends GuiScreen implements IRecipesGui, IShowsRecipeFo
 	public void onStateChange() {
 		updateLayout();
 	}
+
+	@Nullable
+	public RecipeLayout getRecipeLayout(int mouseX, int mouseY) {
+		for (RecipeLayout layout : recipeLayouts) {
+			if (layout.isMouseOver(mouseX, mouseY)) {
+				return layout;
+			}
+		}
+
+		return null;
+	}
 }

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -338,13 +338,20 @@ public class InputHandler {
             return false;
         }
 
-        return switch (pressedKey) {
-            case BOOKMARK -> addBookmark(false);
-            case RECIPE_BOOKMARK -> addBookmark(true);
-            case BOOKMARK_TO_TOP -> handleBookmarkExtra();
-            case SHOW_RECIPE -> showRecipeOrUses(IFocus.Mode.OUTPUT);
-            case SHOW_USES -> showRecipeOrUses(IFocus.Mode.INPUT);
-        };
+        switch (pressedKey) {
+            case BOOKMARK:
+                return addBookmark(false);
+            case RECIPE_BOOKMARK:
+                return addBookmark(true);
+            case BOOKMARK_TO_TOP:
+                return handleBookmarkExtra();
+            case SHOW_RECIPE:
+                return showRecipeOrUses(IFocus.Mode.OUTPUT);
+            case SHOW_USES:
+                return showRecipeOrUses(IFocus.Mode.INPUT);
+        }
+
+        return false;
     }
 
     private boolean addBookmark(boolean isRecipe) {

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -19,6 +19,7 @@ import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.gui.overlay.IngredientListOverlay;
 import mezz.jei.gui.overlay.bookmarks.LeftAreaDispatcher;
 import mezz.jei.gui.recipes.RecipeClickableArea;
+import mezz.jei.gui.recipes.RecipeLayout;
 import mezz.jei.gui.recipes.RecipesGui;
 import mezz.jei.ingredients.IngredientFilter;
 import mezz.jei.ingredients.IngredientRegistry;
@@ -29,6 +30,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.lwjgl.input.Keyboard;
@@ -39,6 +41,25 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class InputHandler {
+
+    private enum KeyBind {
+        SHOW_RECIPE(KeyBindings.showRecipe),
+        SHOW_USES(KeyBindings.showUses),
+        BOOKMARK(KeyBindings.bookmark),
+        BOOKMARK_TO_TOP(KeyBindings.bookmarkToTop),
+        RECIPE_BOOKMARK(KeyBindings.recipeBookmark);
+
+        private KeyBinding keyBind;
+
+        KeyBind(KeyBinding keyBind) {
+            this.keyBind = keyBind;
+        }
+
+        public boolean tryMatch(int keyCode) {
+            return keyBind.isActiveAndMatches(keyCode);
+        }
+    }
+
     private final RecipeRegistry recipeRegistry;
     private final IIngredientRegistry ingredientRegistry;
     private final IngredientFilter ingredientFilter;
@@ -68,18 +89,6 @@ public class InputHandler {
         this.showsRecipeFocuses.add(new GuiContainerWrapper(guiScreenHelper));
     }
 
-    private boolean handleBookmarkExtra() {
-        boolean forceAdd = (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) && Keyboard.isKeyDown(KeyBindings.bookmark.getKeyCode());
-        if (!forceAdd) return false;
-        IClickedIngredient<?> clicked = getIngredientUnderMouseForKey(MouseHelper.getX(), MouseHelper.getY());
-        if (clicked != null) {
-            if (!Config.isBookmarkOverlayEnabled())
-                Config.toggleBookmarkEnabled();
-            return bookmarkList.add(new BookmarkItem<>(clicked.getValue()), true);
-        }
-        return false;
-    }
-
     /**
      * When we have keyboard focus, use Pre
      */
@@ -96,8 +105,6 @@ public class InputHandler {
     @SubscribeEvent
     public void onGuiKeyboardEvent(GuiScreenEvent.KeyboardInputEvent.Post event) {
         if (hasKeyboardFocus()) return;
-        if (handleBookmarkExtra())
-            event.setCanceled(true);
         else if (handleKeyEvent())
             event.setCanceled(true);
     }
@@ -311,36 +318,67 @@ public class InputHandler {
     }
 
     private boolean handleFocusKeybinds(int eventKey) {
-        final boolean showRecipe = KeyBindings.showRecipe.isActiveAndMatches(eventKey);
-        final boolean showUses = KeyBindings.showUses.isActiveAndMatches(eventKey);
-        final boolean bookmark = KeyBindings.bookmark.isActiveAndMatches(eventKey);
-        if (showRecipe || showUses || bookmark) {
-            IClickedIngredient<?> clicked = getIngredientUnderMouseForKey(MouseHelper.getX(), MouseHelper.getY());
-            if (clicked != null) {
-                if (bookmark) {
-                    if (bookmarkList.remove(clicked.getValue())) {
-                        if (bookmarkList.isEmpty() && Config.isBookmarkOverlayEnabled()) {
-                            Config.toggleBookmarkEnabled();
-                        }
-                        return true;
-                    } else {
-                        if (!Config.isBookmarkOverlayEnabled()) {
-                            Config.toggleBookmarkEnabled();
-                        }
-                        return bookmarkList.add(new BookmarkItem<>(clicked.getValue()));
-                    }
-                } else {
-                    IFocus.Mode mode = showRecipe ? IFocus.Mode.OUTPUT : IFocus.Mode.INPUT;
-                    Object value = clicked.getValue();
-                    recipesGui.show(new Focus<>(
-                            mode,
-                            value instanceof BookmarkItem ? ((BookmarkItem<?>) value).ingredient : value));
-                    clicked.onClickHandled();
-                    return true;
-                }
+        KeyBind pressedKey = null;
+        for (KeyBind keyBind : KeyBind.values()) {
+            if (keyBind.tryMatch(eventKey)) {
+                pressedKey = keyBind;
             }
         }
-        return false;
+
+        if (pressedKey == null) {
+            return false;
+        }
+
+        return switch (pressedKey) {
+            case BOOKMARK -> addBookmark(false);
+            case RECIPE_BOOKMARK -> addBookmark(true);
+            case BOOKMARK_TO_TOP -> handleBookmarkExtra();
+            case SHOW_RECIPE -> showRecipeOrUses(IFocus.Mode.OUTPUT);
+            case SHOW_USES -> showRecipeOrUses(IFocus.Mode.INPUT);
+        };
+    }
+
+    private boolean addBookmark(boolean isRecipe) {
+        int mouseX = MouseHelper.getX();
+        int mouseY = MouseHelper.getY();
+        IClickedIngredient<?> clicked = getIngredientUnderMouseForKey(mouseX, mouseY);
+        if (clicked == null) {
+            return false;
+        }
+
+        // TODO: Remove for bookmars with ingredients?
+        if (bookmarkList.remove(clicked.getValue())) {
+            if (bookmarkList.isEmpty() && Config.isBookmarkOverlayEnabled()) {
+                Config.toggleBookmarkEnabled();
+            }
+
+            return true;
+        }
+
+        if (!Config.isBookmarkOverlayEnabled()) {
+            Config.toggleBookmarkEnabled();
+        }
+        
+        if (isRecipe) {
+            RecipeLayout layout = recipesGui.getRecipeLayout(mouseX, mouseY);
+            if (layout == null) {
+                return false;
+            }
+            
+            return layout.addToBookmarks();
+        }
+        
+        return bookmarkList.add(new BookmarkItem<>(clicked.getValue()));
+    }
+
+    private boolean showRecipeOrUses(IFocus.Mode mode) {
+        IClickedIngredient<?> clicked = getIngredientUnderMouseForKey(MouseHelper.getX(), MouseHelper.getY());
+        Object value = clicked.getValue();
+        recipesGui.show(new Focus<>(
+            mode,
+            value instanceof BookmarkItem ? ((BookmarkItem<?>) value).ingredient : value));
+            clicked.onClickHandled();
+        return true;
     }
 
     private boolean isContainerTextFieldFocused() {
@@ -352,4 +390,15 @@ public class InputHandler {
         return textField != null && textField.getVisible() && textField.isFocused();
     }
 
+    private boolean handleBookmarkExtra() {
+        IClickedIngredient<?> clicked = getIngredientUnderMouseForKey(MouseHelper.getX(), MouseHelper.getY());
+        if (clicked != null) {
+            if (!Config.isBookmarkOverlayEnabled())
+                Config.toggleBookmarkEnabled();
+
+            return bookmarkList.add(new BookmarkItem<>(clicked.getValue()), true);
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -134,7 +134,7 @@ public class InputHandler {
                     }
                 }
             } else {
-                cancelEvent = handleMouseRelease(guiScreen, mouseX, mouseY) && clickHandled.remove(eventButton);
+                cancelEvent = handleMouseRelease(guiScreen, mouseX, mouseY) || clickHandled.remove(eventButton);
             }
         } else if (Mouse.getEventDWheel() != 0) {
             cancelEvent = handleMouseScroll(Mouse.getEventDWheel(), mouseX, mouseY);
@@ -381,6 +381,10 @@ public class InputHandler {
 
     private boolean showRecipeOrUses(IFocus.Mode mode) {
         IClickedIngredient<?> clicked = getIngredientUnderMouseForKey(MouseHelper.getX(), MouseHelper.getY());
+        if (clicked == null) {
+            return false;
+        }
+
         Object value = clicked.getValue();
         recipesGui.show(new Focus<>(
             mode,

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -133,14 +133,22 @@ public class InputHandler {
                         clickHandled.add(eventButton);
                     }
                 }
-            } else if (clickHandled.contains(eventButton)) {
-                clickHandled.remove(eventButton);
-                cancelEvent = true;
+            } else {
+                cancelEvent = handleMouseRelease(guiScreen, mouseX, mouseY) && clickHandled.remove(eventButton);
             }
         } else if (Mouse.getEventDWheel() != 0) {
             cancelEvent = handleMouseScroll(Mouse.getEventDWheel(), mouseX, mouseY);
         }
         return cancelEvent;
+    }
+
+    private boolean handleMouseRelease(GuiScreen guiScreen, int mouseX, int mouseY) {
+        final int eventButton = Mouse.getEventButton();
+        if (leftAreaDispatcher.handleMouseReleased(mouseX, mouseY, eventButton)) {
+            return true;
+        }
+
+        return false;
     }
 
     private boolean handleMouseScroll(int dWheel, int mouseX, int mouseY) {
@@ -322,6 +330,7 @@ public class InputHandler {
         for (KeyBind keyBind : KeyBind.values()) {
             if (keyBind.tryMatch(eventKey)) {
                 pressedKey = keyBind;
+                break;
             }
         }
 
@@ -346,7 +355,6 @@ public class InputHandler {
             return false;
         }
 
-        // TODO: Remove for bookmars with ingredients?
         if (bookmarkList.remove(clicked.getValue())) {
             if (bookmarkList.isEmpty() && Config.isBookmarkOverlayEnabled()) {
                 Config.toggleBookmarkEnabled();

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -52,6 +52,7 @@ key.jei.toggleEditMode=Toggle Hide/Edit Mode
 key.jei.previousPage=Show Previous Page
 key.jei.nextPage=Show Next Page
 key.jei.bookmark=Add/Remove a Bookmarked Ingredient
+key.hei.bookmarkToTop=Add a Bookmarked Ingredient to the top
 key.hei.recipeBookmark=Add/Remove a Bookmarked Recipe
 key.hei.toggleBookmarkOverlay=Show/Hide Bookmarked Ingredients
 key.hei.crafting=Autocraft Selected Bookmarked Recipes

--- a/src/main/resources/assets/jei/lang/pl_pl.lang
+++ b/src/main/resources/assets/jei/lang/pl_pl.lang
@@ -46,6 +46,8 @@ key.jei.toggleEditMode=Włącz/wyłącz tryb ukrywania
 key.jei.previousPage=Pokaż poprzednią stronę
 key.jei.nextPage=Pokaż następną stronę
 key.jei.bookmark=Dodaj/usuń składnik dodany do zakładek
+key.hei.bookmarkAtTop=Dodaj składnik na początku listy
+key.hei.recipeBookmark=Dodaj recepturę do zakładek
 key.hei.toggleBookmarkOverlay=Pokaż/ukryj składniki dodane do zakładek
 
 # Config


### PR DESCRIPTION
Adds the ability to reorder groups by holding CTRL and dragging with mouse. Also adds a hotkey for adding recipes to bookmark list. 

Planned to add the ability to extend the groups by dragging, but due to limited time won't be able to. Partial implementation of that is in commit 529ee9599efd1f2e964106ec32da364b88b7e13f, but it was too broken. Sometimes ordering would get all messed up and old sub-recipes would remain in the old group if they are added to favorites.