### PR TITLE
fix bug

### DIFF
--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGridWithNavigation.java
@@ -1,5 +1,6 @@
 package mezz.jei.gui.overlay.bookmarks;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import mezz.jei.Internal;
 import mezz.jei.bookmarks.BookmarkItem;
 import mezz.jei.config.Config;
@@ -33,7 +34,7 @@ public class BookmarkGridWithNavigation implements IShowsRecipeFocuses, IMouseHa
 
     private int firstItemIndex = 0;
     private final IPaged pageDelegate;
-    private List<Integer> pageBoundaries;
+    private IntList pageBoundaries;
     private final PageNavigation navigation;
 
     private BookmarkGroupOrganizer groupOrganizer;
@@ -190,7 +191,7 @@ public class BookmarkGridWithNavigation implements IShowsRecipeFocuses, IMouseHa
                 updateLayout(true);
                 return true;
             }
-            firstItemIndex = pageBoundaries.get(pageNum + 1);
+            firstItemIndex = pageBoundaries.getInt(pageNum + 1);
             updateLayout(false);
             return true;
         }
@@ -198,7 +199,7 @@ public class BookmarkGridWithNavigation implements IShowsRecipeFocuses, IMouseHa
         @Override
         public boolean previousPage() {
             int pageNum = getPageNumber();
-            firstItemIndex = pageBoundaries.get(pageNum == 0 ? pageBoundaries.size() - 1 : pageNum - 1);
+            firstItemIndex = pageBoundaries.getInt(pageNum == 0 ? pageBoundaries.size() - 1 : pageNum - 1);
             updateLayout(false);
             return true;
         }
@@ -232,7 +233,7 @@ public class BookmarkGridWithNavigation implements IShowsRecipeFocuses, IMouseHa
                     index--;
                 }
             }
-            firstItemIndex = pageBoundaries.get(index); // This side effect is fine.
+            firstItemIndex = pageBoundaries.getInt(index); // This side effect is fine.
             return index;
         }
     }

--- a/src/main/java/mezz/jei/render/BookmarkListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/BookmarkListBatchRenderer.java
@@ -1,6 +1,7 @@
 package mezz.jei.render;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import mezz.jei.config.Config;
 import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.gui.overlay.bookmarks.group.BookmarkGroupOrganizer;
@@ -33,7 +34,7 @@ public class BookmarkListBatchRenderer extends IngredientListBatchRenderer {
         if (!ingredientList.isEmpty()) {
             int i = startIndex;
             int currentGroup = ingredientList.get(i).getGroupIndex();
-            List<Integer> groupIndices = new IntArrayList();
+            IntList groupIndices = new IntArrayList();
             for (List<IngredientListSlot> row : slots) {
                 for (int column = 0; column < row.size(); column++) {
                     IngredientListSlot ingredientListSlot = row.get(column);
@@ -69,8 +70,8 @@ public class BookmarkListBatchRenderer extends IngredientListBatchRenderer {
         invalidateBuffer();
     }
 
-    public List<Integer> sizePages(List<IIngredientListElement> ingredientList) {
-        List<Integer> pages = new IntArrayList();
+    public IntList sizePages(List<IIngredientListElement> ingredientList) {
+        IntList pages = new IntArrayList();
         pages.add(0);
         if (ingredientList.isEmpty() || slots.isEmpty()) {
             return pages;
@@ -78,14 +79,25 @@ public class BookmarkListBatchRenderer extends IngredientListBatchRenderer {
 
         int ingredientIndex = 0;
         int currentGroup = ingredientList.get(ingredientIndex).getGroupIndex();
-        while (true) {
-            for (int rowIndex = 0; rowIndex < slots.size(); rowIndex++) {
+
+        while (ingredientIndex < ingredientList.size()) {
+            int pageStartIndex = ingredientIndex;
+            boolean hasUsableSlot = false;
+
+            for (int rowIndex = 0; rowIndex < slots.size() && ingredientIndex < ingredientList.size(); rowIndex++) {
                 List<IngredientListSlot> row = slots.get(rowIndex);
-                for (int column = 0; column < row.size(); column++) {
+                if (row.isEmpty()) {
+                    continue;
+                }
+
+                for (int column = 0; column < row.size() && ingredientIndex < ingredientList.size(); column++) {
                     IngredientListSlot ingredientListSlot = row.get(column);
                     if (ingredientListSlot.isBlocked()) {
                         continue;
                     }
+
+                    hasUsableSlot = true;
+
                     IIngredientListElement<?> element = ingredientList.get(ingredientIndex);
                     if (element.getGroupIndex() != currentGroup || element.startsNewRow()) {
                         currentGroup = element.getGroupIndex();
@@ -93,12 +105,21 @@ public class BookmarkListBatchRenderer extends IngredientListBatchRenderer {
                             break;
                         }
                     }
-                    if (ingredientList.size() <= ++ingredientIndex) {
-                        return pages;
-                    }
+
+                    ingredientIndex++;
                 }
             }
-            pages.add(ingredientIndex);
+
+            if (!hasUsableSlot || ingredientIndex == pageStartIndex) {
+                return pages;
+            }
+
+            if (ingredientIndex < ingredientList.size()) {
+                pages.add(ingredientIndex);
+                currentGroup = ingredientList.get(ingredientIndex).getGroupIndex();
+            }
         }
+
+        return pages;
     }
 }


### PR DESCRIPTION
BookmarkListBatchRenderer#sizePages could enter an infinite loop when a page had no usable slots, because the outer loop assumed each pass would advance ingredientIndex.
This change records the page start index and checks whether a full page scan actually consumed any ingredients.
If a pass makes no progress, the method now returns the current page list instead of repeating the same page forever.
Normal paging behavior is unchanged, but empty, fully blocked, or otherwise non-progressing layouts no longer hang.