### PR TITLE
Make Collapsible Groups Colorable

### DIFF
--- a/src/api/java/mezz/jei/api/ICollapsibleGroupRegistry.java
+++ b/src/api/java/mezz/jei/api/ICollapsibleGroupRegistry.java
@@ -72,6 +72,15 @@ public interface ICollapsibleGroupRegistry {
 		<V> Builder addAny(IIngredientType<V> type, Predicate<V> filter);
 
 		/**
+		 * Set the color for the collapsable group.
+		 *
+		 * @param backgroundColor the background color for the group
+		 * @param borderColor the color displayed on the border of the group
+		 * @return this builder for chaining
+		 */
+		Builder color(int backgroundColor, int borderColor);
+
+		/**
 		 * Finalizes the current builder and registers it
 		 */
 		void build();

--- a/src/main/java/mezz/jei/config/CustomGroupsConfig.java
+++ b/src/main/java/mezz/jei/config/CustomGroupsConfig.java
@@ -3,6 +3,7 @@ package mezz.jei.config;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import mezz.jei.ingredients.group.CollapsedGroupIngredient;
 import mezz.jei.util.Log;
 
 import javax.annotation.Nullable;
@@ -88,22 +89,28 @@ public class CustomGroupsConfig {
 	public static class CustomGroup {
 		public String id;
 		public String displayName;
+		public int backgroundColor;
+		public int borderColor;
 		public List<String> itemUids;
 
 		public CustomGroup() {
 			this.id = "";
 			this.displayName = "";
+			this.backgroundColor = CollapsedGroupIngredient.BACKGROUND_COLOR_SMOKE;
+			this.borderColor = CollapsedGroupIngredient.BORDER_COLOR_SMOKE;
 			this.itemUids = new ArrayList<>();
 		}
 
-		public CustomGroup(String id, String displayName, List<String> itemUids) {
+		public CustomGroup(String id, String displayName, int backgroundColor, int borderColor, List<String> itemUids) {
 			this.id = id;
 			this.displayName = displayName;
+			this.backgroundColor = backgroundColor;
+			this.borderColor = borderColor;
 			this.itemUids = new ArrayList<>(itemUids);
 		}
 
 		public CustomGroup copy() {
-			return new CustomGroup(id, displayName, new ArrayList<>(itemUids));
+			return new CustomGroup(id, displayName, backgroundColor, borderColor, new ArrayList<>(itemUids));
 		}
 	}
 }

--- a/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCollapsibleGroups.java
+++ b/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCollapsibleGroups.java
@@ -208,7 +208,7 @@ public class GuiCollapsibleGroups extends GuiScreen {
 			String newId = "custom:" + UUID.randomUUID().toString().substring(0, 8);
 			CustomGroupsConfig customGroupsConfig = Config.getCustomGroupsConfig();
 			if (customGroupsConfig != null) {
-				CustomGroupsConfig.CustomGroup newGroup = new CustomGroupsConfig.CustomGroup(newId, "New Group", new ArrayList<>());
+				CustomGroupsConfig.CustomGroup newGroup = new CustomGroupsConfig.CustomGroup(newId, "New Group", CollapsedGroupIngredient.BACKGROUND_COLOR_SMOKE, CollapsedGroupIngredient.BORDER_COLOR_SMOKE, new ArrayList<>());
 				this.mc.displayGuiScreen(new GuiCustomGroupEditor(this, newGroup));
 			}
 			return;

--- a/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCollapsibleGroups.java
+++ b/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCollapsibleGroups.java
@@ -193,8 +193,8 @@ public class GuiCollapsibleGroups extends GuiScreen {
 		// Page navigation
 		if (totalPages > 1) {
 			int navY = layoutContentTop + cardsPerCol * (CARD_HEIGHT + CARD_PADDING) + 4;
-			this.buttonList.add(new GuiButton(BTN_PREV_PAGE, layoutContentLeft, navY, 40, 20, "<"));
-			this.buttonList.add(new GuiButton(BTN_NEXT_PAGE, layoutContentLeft + layoutContentWidth - 40, navY, 40, 20, ">"));
+			this.buttonList.add(new GuiButton(BTN_PREV_PAGE, layoutContentLeft, navY, 20, 20, "<"));
+			this.buttonList.add(new GuiButton(BTN_NEXT_PAGE, layoutContentLeft + layoutContentWidth - 20, navY, 20, 20, ">"));
 		}
 	}
 

--- a/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
+++ b/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
@@ -142,12 +142,12 @@ public class GuiCustomGroupEditor extends GuiScreen {
 
 		// Page nav buttons for left grid
 		int leftNavY = this.height - 22;
-		this.buttonList.add(new GuiButton(BTN_PREV_PAGE, 4, leftNavY, 30, 20, "<"));
-		this.buttonList.add(new GuiButton(BTN_NEXT_PAGE, panelDivider - 34, leftNavY, 30, 20, ">"));
+		this.buttonList.add(new GuiButton(BTN_PREV_PAGE, 4, leftNavY, 20, 20, "<"));
+		this.buttonList.add(new GuiButton(BTN_NEXT_PAGE, panelDivider - 24, leftNavY, 20, 20, ">"));
 
 		// Page nav buttons for right grid
-		this.buttonList.add(new GuiButton(BTN_PREV_SEL_PAGE, panelDivider + 4, leftNavY, 30, 20, "<"));
-		this.buttonList.add(new GuiButton(BTN_NEXT_SEL_PAGE, this.width - 34, leftNavY, 30, 20, ">"));
+		this.buttonList.add(new GuiButton(BTN_PREV_SEL_PAGE, panelDivider + 4, leftNavY, 20, 20, "<"));
+		this.buttonList.add(new GuiButton(BTN_NEXT_SEL_PAGE, this.width - 24, leftNavY, 20, 20, ">"));
 
 		updateFilteredItems();
 		leftPage = Math.max(0, Math.min(savedFirstItemIndex / leftItemsPerPage, leftTotalPages - 1));

--- a/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
+++ b/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
@@ -42,6 +42,8 @@ public class GuiCustomGroupEditor extends GuiScreen {
 	private static final int BTN_NEXT_PAGE = 3;
 	private static final int BTN_PREV_SEL_PAGE = 4;
 	private static final int BTN_NEXT_SEL_PAGE = 5;
+	private static final int BTN_CLEAR = 6;
+
 	private static final int FIELD_NAME_BOX = 10;
 	private static final int FIELD_SEARCH_BOX = 11;
 	private static final int FIELD_BACKGROUND_COLOR_BOX = 12;
@@ -178,6 +180,10 @@ public class GuiCustomGroupEditor extends GuiScreen {
 		// Page nav buttons for right grid
 		this.buttonList.add(new GuiButton(BTN_PREV_SEL_PAGE, panelDivider + 4, leftNavY, 20, 20, "<"));
 		this.buttonList.add(new GuiButton(BTN_NEXT_SEL_PAGE, this.width - 24, leftNavY, 20, 20, ">"));
+
+		// Clear all items
+		this.buttonList.add(new GuiButton(BTN_CLEAR, panelDivider + (this.width - panelDivider) / 2 - 25, leftNavY, 50, 20,
+				Translator.translateToLocal("hei.gui.collapsible.editor.clear")));
 
 		updateFilteredItems();
 		leftPage = Math.max(0, Math.min(savedFirstItemIndex / leftItemsPerPage, leftTotalPages - 1));
@@ -404,6 +410,10 @@ public class GuiCustomGroupEditor extends GuiScreen {
 				break;
 			case BTN_NEXT_SEL_PAGE:
 				rightPage = Math.min(rightTotalPages - 1, rightPage + 1);
+				break;
+			case BTN_CLEAR:
+				selectedUids.clear();
+				updateSelectedStacks();
 				break;
 		}
 	}

--- a/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
+++ b/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
@@ -7,6 +7,7 @@ import mezz.jei.config.Config;
 import mezz.jei.config.CustomGroupsConfig;
 import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.ingredients.IngredientFilter;
+import mezz.jei.ingredients.group.CollapsedGroupIngredient;
 import mezz.jei.util.Translator;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
@@ -17,6 +18,7 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.client.config.GuiUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
@@ -42,6 +44,8 @@ public class GuiCustomGroupEditor extends GuiScreen {
 	private static final int BTN_NEXT_SEL_PAGE = 5;
 	private static final int FIELD_NAME_BOX = 10;
 	private static final int FIELD_SEARCH_BOX = 11;
+	private static final int FIELD_BACKGROUND_COLOR_BOX = 12;
+	private static final int FIELD_BORDER_COLOR_BOX = 13;
 
 	private final GuiCollapsibleGroups parentScreen;
 	private final CustomGroupsConfig.CustomGroup group;
@@ -55,6 +59,10 @@ public class GuiCustomGroupEditor extends GuiScreen {
 	private GuiTextField nameField;
 	@Nullable
 	private GuiTextField searchField;
+	@Nullable
+	private GuiTextField backgroundColorField;
+	@Nullable
+	private GuiTextField borderColorField;
 
 	// Left grid (all items)
 	private List<IIngredientListElement> filteredItems = Collections.emptyList();
@@ -99,6 +107,17 @@ public class GuiCustomGroupEditor extends GuiScreen {
 		this.selectedUids.addAll(group.itemUids);
 	}
 
+	private static int getColor(String hex, int fallback) {
+		// don't color when only the alpha values are present
+		if (hex.length() <= 2) return fallback;
+		hex = StringUtils.rightPad(hex, 8, '0');
+		try {
+			return Integer.parseUnsignedInt(hex, 16);
+		} catch (NumberFormatException ignored) {
+			return fallback;
+		}
+	}
+
 	@Override
 	public void initGui() {
 		super.initGui();
@@ -113,10 +132,13 @@ public class GuiCustomGroupEditor extends GuiScreen {
 		nameField.setMaxStringLength(40);
 		nameField.setText(group.displayName != null ? group.displayName : "");
 
-		// Search field — restore saved text so the user's last search carries over
-		searchField = new GuiTextField(11, this.fontRenderer, 4, topBarHeight - 18, panelDivider - 12, 14);
-		searchField.setMaxStringLength(128);
-		searchField.setText(savedSearchText);
+		// color fields
+		backgroundColorField = new GuiTextField(FIELD_BACKGROUND_COLOR_BOX, this.fontRenderer, 62, topBarHeight - 20, 55, 16);
+		backgroundColorField.setMaxStringLength(8);
+		backgroundColorField.setText(Integer.toHexString(group.backgroundColor));
+		borderColorField = new GuiTextField(FIELD_BORDER_COLOR_BOX, this.fontRenderer, 121, topBarHeight - 20, 55, 16);
+		borderColorField.setMaxStringLength(8);
+		borderColorField.setText(Integer.toHexString(group.borderColor));
 
 		// Save & Cancel buttons
 		this.buttonList.add(new GuiButton(BTN_SAVE, panelDivider + 4, 4, 50, 20,
@@ -390,6 +412,12 @@ public class GuiCustomGroupEditor extends GuiScreen {
 		if (nameField != null) {
 			group.displayName = nameField.getText();
 		}
+		if (backgroundColorField != null) {
+			group.backgroundColor = getColor(backgroundColorField.getText(), CollapsedGroupIngredient.BACKGROUND_COLOR_SMOKE);
+		}
+		if (borderColorField != null) {
+			group.borderColor = getColor(borderColorField.getText(), CollapsedGroupIngredient.BORDER_COLOR_SMOKE);
+		}
 		group.itemUids = new ArrayList<>(selectedUids);
 
 		CustomGroupsConfig customGroupsConfig = Config.getCustomGroupsConfig();
@@ -421,6 +449,41 @@ public class GuiCustomGroupEditor extends GuiScreen {
 			6, 10, 0xFFFFFF);
 		if (nameField != null) {
 			nameField.drawTextBox();
+		}
+
+		// Color label
+		this.fontRenderer.drawStringWithShadow(
+				Translator.translateToLocal("hei.gui.collapsible.editor.color") + ":",
+				6, 32, 0xFFFFFF);
+		if (backgroundColorField != null) {
+			backgroundColorField.drawTextBox();
+		}
+		if (borderColorField != null) {
+			borderColorField.drawTextBox();
+		}
+
+		if (backgroundColorField != null && borderColorField != null) {
+			int backgroundColor = getColor(backgroundColorField.getText(), CollapsedGroupIngredient.BACKGROUND_COLOR_SMOKE);
+			int borderColor = getColor(borderColorField.getText(), CollapsedGroupIngredient.BORDER_COLOR_SMOKE);
+			int x = 180;
+			int y = 28;
+			GlStateManager.disableLighting();
+			GlStateManager.enableBlend();
+			GlStateManager.tryBlendFuncSeparate(
+					GlStateManager.SourceFactor.SRC_ALPHA,
+					GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+					GlStateManager.SourceFactor.ONE,
+					GlStateManager.DestFactor.ZERO
+			);
+			// create a 4x1 space to show what a typical group looks like
+			drawRect(x, y, x + 64, y + 16, backgroundColor);
+			GlStateManager.disableDepth();
+			GuiScreen.drawRect(x, y, x + 64, y + 1, borderColor);
+			GuiScreen.drawRect(x + 64 - 1, y + 1, x + 64, y + 16, borderColor);
+			GuiScreen.drawRect(x + 64 - 1, y + 16 - 1, x, y + 16, borderColor);
+			GuiScreen.drawRect(x, y + 1, x + 1, y + 16, borderColor);
+			GlStateManager.enableDepth();
+			GlStateManager.disableBlend();
 		}
 
 		// Search field
@@ -646,6 +709,12 @@ public class GuiCustomGroupEditor extends GuiScreen {
 		if (nameField != null) {
 			nameField.mouseClicked(mouseX, mouseY, mouseButton);
 		}
+		if (backgroundColorField != null) {
+			backgroundColorField.mouseClicked(mouseX, mouseY, mouseButton);
+		}
+		if (borderColorField != null) {
+			borderColorField.mouseClicked(mouseX, mouseY, mouseButton);
+		}
 		if (searchField != null) {
 			searchField.mouseClicked(mouseX, mouseY, mouseButton);
 			// Right-click clears search
@@ -837,6 +906,14 @@ public class GuiCustomGroupEditor extends GuiScreen {
 			nameField.textboxKeyTyped(typedChar, keyCode);
 			return;
 		}
+		if (backgroundColorField != null && backgroundColorField.isFocused()) {
+			backgroundColorField.textboxKeyTyped(typedChar, keyCode);
+			return;
+		}
+		if (borderColorField != null && borderColorField.isFocused()) {
+			borderColorField.textboxKeyTyped(typedChar, keyCode);
+			return;
+		}
 		if (searchField != null && searchField.isFocused()) {
 			String before = searchField.getText();
 			searchField.textboxKeyTyped(typedChar, keyCode);
@@ -894,6 +971,12 @@ public class GuiCustomGroupEditor extends GuiScreen {
 		super.updateScreen();
 		if (nameField != null) {
 			nameField.updateCursorCounter();
+		}
+		if (backgroundColorField != null) {
+			backgroundColorField.updateCursorCounter();
+		}
+		if (borderColorField != null) {
+			borderColorField.updateCursorCounter();
 		}
 		if (searchField != null) {
 			searchField.updateCursorCounter();

--- a/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
+++ b/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
@@ -40,6 +40,8 @@ public class GuiCustomGroupEditor extends GuiScreen {
 	private static final int BTN_NEXT_PAGE = 3;
 	private static final int BTN_PREV_SEL_PAGE = 4;
 	private static final int BTN_NEXT_SEL_PAGE = 5;
+	private static final int FIELD_NAME_BOX = 10;
+	private static final int FIELD_SEARCH_BOX = 11;
 
 	private final GuiCollapsibleGroups parentScreen;
 	private final CustomGroupsConfig.CustomGroup group;
@@ -107,7 +109,7 @@ public class GuiCustomGroupEditor extends GuiScreen {
 		int panelDivider = (int) (this.width * 0.65);
 
 		// Name field
-		nameField = new GuiTextField(10, this.fontRenderer, 62, 6, panelDivider - 70, 16);
+		nameField = new GuiTextField(FIELD_NAME_BOX, this.fontRenderer, 62, 6, panelDivider - 70, 16);
 		nameField.setMaxStringLength(40);
 		nameField.setText(group.displayName != null ? group.displayName : "");
 
@@ -124,7 +126,7 @@ public class GuiCustomGroupEditor extends GuiScreen {
 
 		// Calculate left grid layout
 		int leftWidth = panelDivider - 8;
-		int leftHeight = this.height - topBarHeight - 26; // room for page nav
+		int leftHeight = this.height - topBarHeight - 44; // room for page nav
 		leftCols = Math.max(1, leftWidth / ITEM_SIZE);
 		leftRows = Math.max(1, leftHeight / ITEM_SIZE);
 		leftGridX = (panelDivider - 4 - leftCols * ITEM_SIZE) / 2;
@@ -142,6 +144,12 @@ public class GuiCustomGroupEditor extends GuiScreen {
 
 		// Page nav buttons for left grid
 		int leftNavY = this.height - 22;
+
+		// Search field — restore saved text so the user's last search carries over
+		searchField = new GuiTextField(FIELD_SEARCH_BOX, this.fontRenderer, 6, leftNavY - 18, panelDivider - 12, 14);
+		searchField.setMaxStringLength(128);
+		searchField.setText(savedSearchText);
+
 		this.buttonList.add(new GuiButton(BTN_PREV_PAGE, 4, leftNavY, 20, 20, "<"));
 		this.buttonList.add(new GuiButton(BTN_NEXT_PAGE, panelDivider - 24, leftNavY, 20, 20, ">"));
 

--- a/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
+++ b/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
@@ -659,11 +659,14 @@ public class GuiCustomGroupEditor extends GuiScreen {
 				IIngredientListElement<?> element = filteredItems.get(startIdx + i);
 				List<String> lines = getIngredientTooltipLines(element);
 				if (element.getIngredient() instanceof ItemStack) {
-					boolean alreadySelected = isUidSelected(getIngredientUid(element.getIngredient()));
-					if (alreadySelected) {
-						lines.add(TextFormatting.GOLD + "Ctrl+Click: Remove all variants");
-					} else {
-						lines.add(TextFormatting.GOLD + "Ctrl+Click: Select all variants (Wildcard)");
+					String familyWildcard = getIngredientWildcardUid(element.getIngredient());
+					if (familyWildcard != null && familyWildcard.endsWith(":*")) {
+						boolean alreadySelected = isUidSelected(getIngredientUid(element.getIngredient()));
+						if (alreadySelected) {
+							lines.add(TextFormatting.GOLD + "Ctrl+Click: Remove all variants");
+						} else {
+							lines.add(TextFormatting.GOLD + "Ctrl+Click: Select all variants (Wildcard)");
+						}
 					}
 				}
 				List<String> otherGroups = getOtherGroupNames(getIngredientUid(element.getIngredient()));

--- a/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
+++ b/src/main/java/mezz/jei/gui/overlay/collapsible/GuiCustomGroupEditor.java
@@ -418,7 +418,7 @@ public class GuiCustomGroupEditor extends GuiScreen {
 		// Name label
 		this.fontRenderer.drawStringWithShadow(
 			Translator.translateToLocal("hei.gui.collapsible.editor.name") + ":",
-			4, 10, 0xFFFFFF);
+			6, 10, 0xFFFFFF);
 		if (nameField != null) {
 			nameField.drawTextBox();
 		}

--- a/src/main/java/mezz/jei/ingredients/group/CollapsedGroupIngredient.java
+++ b/src/main/java/mezz/jei/ingredients/group/CollapsedGroupIngredient.java
@@ -28,6 +28,9 @@ public class CollapsedGroupIngredient implements IIngredientListElement<Collapse
 	// Registered as IIngredientType for addon compatibility — addons expect every grid item to have a type
 	public static final IIngredientType<CollapsedGroupIngredient> TYPE = () -> CollapsedGroupIngredient.class;
 
+	public static final int BACKGROUND_COLOR_SMOKE = 0x33555555; // subtle smoke background
+	public static final int BORDER_COLOR_SMOKE = 0xCC888888; // medium smoke border
+
 	public enum GroupSource {
 		DEFAULT,
 		MOD,
@@ -40,17 +43,21 @@ public class CollapsedGroupIngredient implements IIngredientListElement<Collapse
 	private final GroupSource source;
 	private final List<IIngredientListElement<?>> elements;
 	private final Set<String> uids;
+	private final int backgroundColor;
+	private final int borderColor;
 	/** Matches against the raw ingredient object (any type). */
 	private boolean expanded;
 	private boolean visible = true;
 
-	public CollapsedGroupIngredient(String id, String langKey, Set<String> uids, GroupSource source) {
+	public CollapsedGroupIngredient(String id, String langKey, int backgroundColor, int borderColor, Set<String> uids, GroupSource source) {
 		this.id = id;
 		this.langKey = langKey;
 		this.uids = uids;
 		this.source = source;
 		this.expanded = false;
 		this.elements = new ArrayList<>(uids.size());
+		this.backgroundColor = backgroundColor;
+		this.borderColor = borderColor;
 	}
 
 	public String getId() {
@@ -63,6 +70,14 @@ public class CollapsedGroupIngredient implements IIngredientListElement<Collapse
 
 	public GroupSource getSource() {
 		return source;
+	}
+
+	public int getBackgroundColor() {
+		return backgroundColor;
+	}
+
+	public int getBorderColor() {
+		return borderColor;
 	}
 
 	public boolean isExpanded() {

--- a/src/main/java/mezz/jei/ingredients/group/CollapsibleGroupRegistry.java
+++ b/src/main/java/mezz/jei/ingredients/group/CollapsibleGroupRegistry.java
@@ -85,7 +85,7 @@ public class CollapsibleGroupRegistry implements ICollapsibleGroupRegistry {
                 continue;
             }
             Set<String> ingredientUids = new HashSet<>(group.itemUids);
-            CollapsedGroupIngredient ingredient = new CollapsedGroupIngredient(group.id, group.displayName, ingredientUids, CollapsedGroupIngredient.GroupSource.CUSTOM);
+            CollapsedGroupIngredient ingredient = new CollapsedGroupIngredient(group.id, group.displayName, group.backgroundColor, group.borderColor, ingredientUids, CollapsedGroupIngredient.GroupSource.CUSTOM);
             this.groups.put(group.id, new CollapsibleGroup(ingredient));
             amount++;
         }
@@ -124,6 +124,8 @@ public class CollapsibleGroupRegistry implements ICollapsibleGroupRegistry {
         private final CollapsedGroupIngredient.GroupSource groupSource;
         private final String id;
         private final String langKey;
+        private int backgroundColor = CollapsedGroupIngredient.BACKGROUND_COLOR_SMOKE;
+        private int borderColor = CollapsedGroupIngredient.BORDER_COLOR_SMOKE;
         private final Set<String> ingredientUids = new ObjectOpenHashSet<>();
 
         public Builder(CollapsibleGroupRegistry registry, CollapsedGroupIngredient.GroupSource groupSource, String id, String langKey) {
@@ -165,10 +167,17 @@ public class CollapsibleGroupRegistry implements ICollapsibleGroupRegistry {
         }
 
         @Override
+        public ICollapsibleGroupRegistry.Builder color(int backgroundColor, int borderColor) {
+            this.backgroundColor = backgroundColor;
+            this.borderColor = borderColor;
+            return this;
+        }
+
+        @Override
         public void build() {
             this.registry.groups.put(this.id,
                     new CollapsibleGroup(
-                            new CollapsedGroupIngredient(this.id, this.langKey, this.ingredientUids, groupSource)));
+                            new CollapsedGroupIngredient(this.id, this.langKey, this.backgroundColor, this.borderColor, this.ingredientUids, groupSource)));
         }
 
     }

--- a/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
+++ b/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
@@ -92,7 +92,7 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 				GlStateManager.DestFactor.ZERO
 		);
 		// Draw background tint to visually distinguish collapsed groups
-		GuiScreen.drawRect(x, y, x + 16, y + 16, COLLAPSED_BG_COLOR);
+		GuiScreen.drawRect(x, y, x + 16, y + 16, ingredient.getBackgroundColor());
 		GlStateManager.disableBlend();
 
 		if (ingredients.size() == 1) {
@@ -135,7 +135,7 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 			GlStateManager.enableDepth();
 		}
 
-		drawCollapsedBorder(x, y);
+		drawCollapsedBorder(x, y, ingredient.getBorderColor());
 	}
 
 	/**
@@ -171,8 +171,8 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 		// Small triangle indicator in the top-left corner to show it's collapsible
 		GlStateManager.disableLighting();
 		GlStateManager.disableDepth();
-		GuiScreen.drawRect(x, y, x + 4, y + 1, COLLAPSED_BORDER_COLOR);
-		GuiScreen.drawRect(x, y + 1, x + 1, y + 4, COLLAPSED_BORDER_COLOR);
+		GuiScreen.drawRect(x, y, x + 4, y + 1, borderColor);
+		GuiScreen.drawRect(x, y + 1, x + 1, y + 4, borderColor);
 		GlStateManager.enableDepth();
 		GlStateManager.disableBlend();
 	}

--- a/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
+++ b/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
@@ -83,8 +83,17 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 			return;
 		}
 
+		GlStateManager.disableLighting();
+		GlStateManager.enableBlend();
+		GlStateManager.tryBlendFuncSeparate(
+				GlStateManager.SourceFactor.SRC_ALPHA,
+				GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+				GlStateManager.SourceFactor.ONE,
+				GlStateManager.DestFactor.ZERO
+		);
 		// Draw background tint to visually distinguish collapsed groups
 		GuiScreen.drawRect(x, y, x + 16, y + 16, COLLAPSED_BG_COLOR);
+		GlStateManager.disableBlend();
 
 		if (ingredients.size() == 1) {
 			// Single item: render at full size
@@ -151,12 +160,21 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 	}
 
 	private static void drawCollapsedBorder(int x, int y) {
+		GlStateManager.disableLighting();
+		GlStateManager.enableBlend();
+		GlStateManager.tryBlendFuncSeparate(
+				GlStateManager.SourceFactor.SRC_ALPHA,
+				GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+				GlStateManager.SourceFactor.ONE,
+				GlStateManager.DestFactor.ZERO
+		);
 		// Small triangle indicator in the top-left corner to show it's collapsible
 		GlStateManager.disableLighting();
 		GlStateManager.disableDepth();
 		GuiScreen.drawRect(x, y, x + 4, y + 1, COLLAPSED_BORDER_COLOR);
 		GuiScreen.drawRect(x, y + 1, x + 1, y + 4, COLLAPSED_BORDER_COLOR);
 		GlStateManager.enableDepth();
+		GlStateManager.disableBlend();
 	}
 
 	// --- IIngredientRenderer<CollapsedStack> implementation ---

--- a/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
+++ b/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
@@ -159,7 +159,7 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 		}
 	}
 
-	private static void drawCollapsedBorder(int x, int y) {
+	private static void drawCollapsedBorder(int x, int y, int borderColor) {
 		GlStateManager.disableLighting();
 		GlStateManager.enableBlend();
 		GlStateManager.tryBlendFuncSeparate(

--- a/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
+++ b/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
@@ -155,7 +155,7 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 		GlStateManager.disableLighting();
 		GlStateManager.disableDepth();
 		GuiScreen.drawRect(x, y, x + 4, y + 1, COLLAPSED_BORDER_COLOR);
-		GuiScreen.drawRect(x, y, x + 1, y + 4, COLLAPSED_BORDER_COLOR);
+		GuiScreen.drawRect(x, y + 1, x + 1, y + 4, COLLAPSED_BORDER_COLOR);
 		GlStateManager.enableDepth();
 	}
 

--- a/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
+++ b/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
@@ -30,9 +30,6 @@ import java.util.List;
  * plus a semi-transparent background to distinguish it from normal items.
  */
 public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGroupIngredient> {
-	private static final int COLLAPSED_BG_COLOR = 0x33FFFFFF;
-	private static final int COLLAPSED_BORDER_COLOR = 0x55AAAAFF;
-
 	/** Singleton registered with the ingredient type system — {@code collapsedStack} is null. */
 	public static final CollapsedGroupRenderer INSTANCE = new CollapsedGroupRenderer(null);
 

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -338,13 +338,13 @@ public class IngredientListBatchRenderer {
             GlStateManager.SourceFactor.ONE,
             GlStateManager.DestFactor.ZERO
         );
-        int bgColor = 0x33555555; // subtle smoke background
-        int borderColor = 0xCC888888; // medium smoke border
-        for (List<Rectangle> slots : expandedGroupSlots.values()) {
+        for (Map.Entry<CollapsedGroupIngredient, List<Rectangle>> slots : expandedGroupSlots.entrySet()) {
+            int bgColor = slots.getKey().getBackgroundColor();
+            int borderColor = slots.getKey().getBorderColor();
             // Build a fast lookup set keyed by "x,y" to detect adjacent group slots.
             Set<String> keys = new HashSet<>();
-            for (Rectangle r : slots) keys.add(r.x + "," + r.y);
-            for (Rectangle r : slots) {
+            for (Rectangle r : slots.getValue()) keys.add(r.x + "," + r.y);
+            for (Rectangle r : slots.getValue()) {
                 // Background fill for each slot in group
                 Gui.drawRect(r.x, r.y, r.x + r.width, r.y + r.height, bgColor);
 

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -235,6 +235,7 @@ hei.gui.collapsible.editor.title=Selected Items
 hei.gui.collapsible.editor.name=Name
 hei.gui.collapsible.editor.color=Color
 hei.gui.collapsible.editor.save=Save
+hei.gui.collapsible.editor.clear=Clear
 hei.gui.collapsible.editor.selected=%d selected
 hei.gui.collapsible.confirmDelete=Delete?
 hei.tooltip.missing_ingredients=§cMissing Ingredients:

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -233,6 +233,7 @@ hei.gui.collapsible.defaultGroup=Default
 hei.gui.collapsible.itemCount=%d items
 hei.gui.collapsible.editor.title=Selected Items
 hei.gui.collapsible.editor.name=Name
+hei.gui.collapsible.editor.color=Color
 hei.gui.collapsible.editor.save=Save
 hei.gui.collapsible.editor.selected=%d selected
 hei.gui.collapsible.confirmDelete=Delete?


### PR DESCRIPTION
changes in this PR:
- make the background color and border color configurable per group.
  - add `color(backgroundColor, borderColor)` to `ICollapsibleGroupRegistry.Builder`.
  - default color is the prior defaults, named `BACKGROUND_COLOR_SMOKE` and `BORDER_COLOR_SMOKE`.
  - add color fields and a preview when editing a collapsible group.
- shrink the width of some buttons to make them a square.
- fix the collapsed display having an overlap in the border color (rendering the vertical and horizontal in the same spot).
- when rendering the collapsed group, use the same blend logic as when rendering the expanded group.
- when editing a collapsible group, only render the "ctrl+click" tooltip if there is a wildcard for the hovered ingredient.
- add a button the clear all selected ingredients in a group.
- when editing a collapsible group, move the search bar to the bottom (instead of the top).

related to #175 