### PR TITLE
Fix tooltip padding + merge JEI history from JEI-Utilities by vfyjxf

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -385,6 +385,14 @@ public final class Config {
         return values.hideBottomLeftCornerBookmarkButton;
     }
 
+	public static boolean enableHistoryPanel() {
+		return values.enableHistoryPanel;
+	}
+
+	public static boolean isHistoryPanelOnLeft() {
+		return values.isHistoryPanelOnLeft;
+	}
+
     public static int getRecipeBookmarkGroupColor() {
 		return values.recipeBookmarkGroupColor;
 	}
@@ -583,6 +591,10 @@ public final class Config {
 		values.hideBottomRightCornerConfigButton = config.getBoolean(CATEGORY_MISC, "hideBottomRightCornerConfigButton", defaultValues.hideBottomRightCornerConfigButton);
 
         values.hideBottomLeftCornerBookmarkButton = config.getBoolean(CATEGORY_MISC, "hideBottomLeftCornerBookmarkButton", defaultValues.hideBottomLeftCornerBookmarkButton);
+
+		values.enableHistoryPanel = config.getBoolean(CATEGORY_MISC, "enableHistoryPanel", defaultValues.enableHistoryPanel);
+
+		values.isHistoryPanelOnLeft = config.getBoolean(CATEGORY_MISC, "isHistoryPanelOnLeft", defaultValues.isHistoryPanelOnLeft);
 
 		{
 			boolean prev = values.collapsibleGroupsEnabled;

--- a/src/main/java/mezz/jei/config/ConfigValues.java
+++ b/src/main/java/mezz/jei/config/ConfigValues.java
@@ -53,6 +53,8 @@ public class ConfigValues {
 	public boolean skipShowingProgressBar = false;
 	public boolean hideBottomRightCornerConfigButton = false;
     public boolean hideBottomLeftCornerBookmarkButton = false;
+	public boolean enableHistoryPanel = true;
+	public boolean isHistoryPanelOnLeft = true;
 
     // category
 	public List<String> categoryUidOrder = new ArrayList<>();

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
@@ -47,8 +47,7 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 
 	private Rectangle area = new Rectangle();
 	protected final IngredientListBatchRenderer guiIngredientSlots;
-
-	private final IngredientGridHistoryProvider historyProvider;
+	protected final IngredientGridHistoryProvider historyProvider;
 
 	public IngredientGrid(IngredientListBatchRenderer guiIngredientSlots, GridAlignment alignment, boolean enableHistory) {
 		this.alignment = alignment;

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
@@ -83,7 +83,7 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 		this.area = new Rectangle(x, y, width, height);
 		this.guiIngredientSlots.clear();
 
-		if (historyProvider.isEnable()) {
+		if (historyProvider.isEnabled()) {
 			historyProvider.updateColumns(columns);
 			historyProvider.updateHistorySize(columns);
 			historyProvider.clearHistorySlots();
@@ -133,7 +133,7 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 		guiIngredientSlots.render(minecraft);
 		guiIngredientSlots.renderExpandedGroupOutlines();
 
-		if (historyProvider.isEnable()) {
+		if (historyProvider.isEnabled()) {
 			historyProvider.drawExtra(minecraft);
 		}
 
@@ -173,7 +173,7 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 						}
 					}
 
-					if (historyProvider.isEnable()) {
+					if (historyProvider.isEnabled()) {
 						historyProvider.drawTooltipsExtra(minecraft, mouseX, mouseY);
 					}
 				}
@@ -261,7 +261,7 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 			result = null;
 		}
 
-		if (historyProvider.isEnable()) {
+		if (historyProvider.isEnabled()) {
 			result = historyProvider.getIngredientUnderMouseExtra(result, mouseX, mouseY);
 		}
 

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
@@ -26,12 +26,14 @@ import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -46,13 +48,16 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 	private Rectangle area = new Rectangle();
 	protected final IngredientListBatchRenderer guiIngredientSlots;
 
-	public IngredientGrid(IngredientListBatchRenderer guiIngredientSlots, GridAlignment alignment) {
+	private final IngredientGridHistoryProvider historyProvider;
+
+	public IngredientGrid(IngredientListBatchRenderer guiIngredientSlots, GridAlignment alignment, boolean enableHistory) {
 		this.alignment = alignment;
 		this.guiIngredientSlots = guiIngredientSlots;
+		this.historyProvider = new IngredientGridHistoryProvider(enableHistory);
 	}
 
 	public IngredientGrid(GridAlignment alignment) { // Left in for compatibility with JEI Utilities
-		this(new IngredientListBatchRenderer(), alignment);
+		this(new IngredientListBatchRenderer(), alignment, false);
 	}
 
 	public int size() {
@@ -78,23 +83,39 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 		this.area = new Rectangle(x, y, width, height);
 		this.guiIngredientSlots.clear();
 
+		if (historyProvider.isEnable()) {
+			historyProvider.updateColumns(columns);
+			historyProvider.updateHistorySize(columns);
+			historyProvider.clearHistorySlots();
+		}
+
 		if (rows == 0 || columns < Config.smallestNumColumns) {
 			return false;
 		}
 
-		for (int row = 0; row < rows; row++) {
-			List<IngredientListSlot> ingredientRow = new ArrayList<>();
-			int y1 = y + (row * INGREDIENT_HEIGHT);
-			for (int column = 0; column < columns; column++) {
-				int x1 = xOffset + (column * INGREDIENT_WIDTH);
-				IngredientListSlot ingredientListSlot = new IngredientListSlot(x1, y1, INGREDIENT_PADDING);
-				Rectangle stackArea = ingredientListSlot.getArea();
-				final boolean blocked = MathUtil.intersects(exclusionAreas, stackArea);
-				ingredientListSlot.setBlocked(blocked);
-				ingredientRow.add(ingredientListSlot);
+		if (!historyProvider.updateBoundsExtra(
+				columns,
+				rows,
+				y,
+				xOffset,
+				exclusionAreas,
+				this.guiIngredientSlots)) {
+
+			for (int row = 0; row < rows; row++) {
+				List<IngredientListSlot> ingredientRow = new ArrayList<>();
+				int y1 = y + (row * INGREDIENT_HEIGHT);
+				for (int column = 0; column < columns; column++) {
+					int x1 = xOffset + (column * INGREDIENT_WIDTH);
+					IngredientListSlot ingredientListSlot = new IngredientListSlot(x1, y1, INGREDIENT_PADDING);
+					Rectangle stackArea = ingredientListSlot.getArea();
+					final boolean blocked = MathUtil.intersects(exclusionAreas, stackArea);
+					ingredientListSlot.setBlocked(blocked);
+					ingredientRow.add(ingredientListSlot);
+				}
+				this.guiIngredientSlots.add(ingredientRow);
 			}
-			this.guiIngredientSlots.add(ingredientRow);
 		}
+
 		return true;
 	}
 
@@ -111,6 +132,10 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 
 		guiIngredientSlots.render(minecraft);
 		guiIngredientSlots.renderExpandedGroupOutlines();
+
+		if (historyProvider.isEnable()) {
+			historyProvider.drawExtra(minecraft);
+		}
 
 		if (!shouldDeleteItemOnClick(minecraft, mouseX, mouseY) && isMouseOver(mouseX, mouseY)) {
 			CollapsedGroupRenderer collapsedHovered = guiIngredientSlots.getHoveredCollapsed(mouseX, mouseY);
@@ -141,12 +166,15 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 					if (hovered != null) {
 						CollapsedGroupIngredient expandedGroup = guiIngredientSlots.getExpandedCollapsedGroupAt(mouseX, mouseY);
 						if (expandedGroup != null) {
-							String hint = net.minecraft.util.text.TextFormatting.YELLOW
-								+ mezz.jei.util.Translator.translateToLocal("hei.tooltip.collapsed.collapse");
-							hovered.drawTooltip(minecraft, mouseX, mouseY, java.util.Collections.singletonList(hint));
+							String hint = TextFormatting.YELLOW + Translator.translateToLocal("hei.tooltip.collapsed.collapse");
+							hovered.drawTooltip(minecraft, mouseX, mouseY, Collections.singletonList(hint));
 						} else {
 							hovered.drawTooltip(minecraft, mouseX, mouseY);
 						}
+					}
+
+					if (historyProvider.isEnable()) {
+						historyProvider.drawTooltipsExtra(minecraft, mouseX, mouseY);
 					}
 				}
 			}
@@ -222,14 +250,22 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 	@Override
 	@Nullable
 	public IClickedIngredient<?> getIngredientUnderMouse(int mouseX, int mouseY) {
+		IClickedIngredient<?> result;
 		if (isMouseOver(mouseX, mouseY)) {
 			ClickedIngredient<?> clicked = guiIngredientSlots.getIngredientUnderMouse(mouseX, mouseY);
 			if (clicked != null) {
 				clicked.setAllowsCheating();
 			}
-			return clicked;
+			result = clicked;
+		} else {
+			result = null;
 		}
-		return null;
+
+		if (historyProvider.isEnable()) {
+			result = historyProvider.getIngredientUnderMouseExtra(result, mouseX, mouseY);
+		}
+
+		return result;
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
@@ -85,7 +85,6 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 
 		if (historyProvider.isEnabled()) {
 			historyProvider.updateColumns(columns);
-			historyProvider.updateHistorySize(columns);
 			historyProvider.clearHistorySlots();
 		}
 

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
@@ -2,7 +2,6 @@ package mezz.jei.gui.overlay;
 
 import mezz.jei.Internal;
 import mezz.jei.api.ingredients.IIngredientHelper;
-import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.config.Config;
 import mezz.jei.gui.ingredients.IIngredientListElement;
@@ -51,7 +50,6 @@ public class IngredientGridHistoryProvider {
         return enabled;
     }
 
-    private int historySize;
     private int columns;
     private final IngredientListBatchRenderer guiHistoryIngredientSlots;
     @SuppressWarnings("rawtypes")
@@ -88,8 +86,8 @@ public class IngredientGridHistoryProvider {
             return;
         }
 
-        Object normalized = normalizeIngredient(Objects.requireNonNull(ingredientRegistry), value);
-        IIngredientHelper<Object> helper = ingredientRegistry.getIngredientHelper(normalized);
+        Object normalized = normalizeIngredient(value);
+        IIngredientHelper<Object> helper = Objects.requireNonNull(ingredientRegistry).getIngredientHelper(normalized);
 
         IIngredientListElement<?> ingredient = IngredientListElement.create(
                 normalized,
@@ -100,9 +98,6 @@ public class IngredientGridHistoryProvider {
 
         historyIngredientElements.removeIf(element -> areIngredientsEqual(element.getIngredient(), normalized, HISTORY_MATCH_NBT));
         historyIngredientElements.add(0, ingredient);
-        if (historyIngredientElements.size() > historySize) {
-            historyIngredientElements.remove(historyIngredientElements.size() - 1);
-        }
 
         while (historyIngredientElements.size() > USE_ROWS * Config.largestNumColumns) {
             historyIngredientElements.remove(historyIngredientElements.size() - 1);
@@ -130,14 +125,6 @@ public class IngredientGridHistoryProvider {
         this.columns = columns;
     }
 
-    void updateHistorySize(int columns) {
-        if (!enabled) {
-            return;
-        }
-
-        historySize = columns * USE_ROWS;
-    }
-
     void clearHistorySlots() {
         if (!enabled) {
             return;
@@ -159,7 +146,6 @@ public class IngredientGridHistoryProvider {
         }
 
         this.columns = columns;
-        this.historySize = columns * USE_ROWS;
 
         if (rows >= MIN_ROWS) {
             rows = rows - USE_ROWS;
@@ -284,8 +270,8 @@ public class IngredientGridHistoryProvider {
         return Internal.getHelpers().getIngredientBlacklist().isIngredientBlacklisted(ingredient);
     }
 
-    private static <T> T normalizeIngredient(IIngredientRegistry ingredientRegistry, T ingredient) {
-        IIngredientHelper<T> ingredientHelper = ingredientRegistry.getIngredientHelper(ingredient);
+    private static <T> T normalizeIngredient(T ingredient) {
+        IIngredientHelper<T> ingredientHelper = Objects.requireNonNull(ingredientRegistry).getIngredientHelper(ingredient);
         T copy = LegacyUtil.getIngredientCopy(ingredient, ingredientHelper);
         if (copy instanceof ItemStack) {
             ((ItemStack) copy).setCount(1);

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
@@ -1,0 +1,319 @@
+package mezz.jei.gui.overlay;
+
+import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.IIngredientRegistry;
+import mezz.jei.api.recipe.IFocus;
+import mezz.jei.config.Config;
+import mezz.jei.gui.ingredients.IIngredientListElement;
+import mezz.jei.ingredients.IngredientListElement;
+import mezz.jei.input.ClickedIngredient;
+import mezz.jei.input.IClickedIngredient;
+import mezz.jei.render.IngredientListBatchRenderer;
+import mezz.jei.render.IngredientListSlot;
+import mezz.jei.render.IngredientRenderer;
+import mezz.jei.startup.ForgeModIdHelper;
+import mezz.jei.util.LegacyUtil;
+import mezz.jei.util.MathUtil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.lwjgl.opengl.GL11;
+
+import javax.annotation.Nullable;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static mezz.jei.gui.overlay.IngredientGrid.*;
+import static mezz.jei.ingredients.IngredientListElementFactory.ORDER_TRACKER;
+import static mezz.jei.plugins.jei.JEIInternalPlugin.ingredientRegistry;
+
+/**
+ * Extends the original layout logic from JEI to support history rows.
+ * Original implementation by vfyjxf <a href="https://github.com/vfyjxf/JEI-Utilities">JEI-Utilities</a>.
+ */
+public class IngredientGridHistoryProvider {
+
+    private static final List<IngredientGridHistoryProvider> GLOBAL_HISTORY_CONTAINER = new ArrayList<>();
+
+    public static final int USE_ROWS = 2;
+    public static final int MIN_ROWS = 6;
+    public static final int BACKGROUND_COLOR = 0xee555555;
+    public static final boolean HISTORY_MATCH_NBT = true;
+
+    private final boolean enable;
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    private int historySize;
+    private int columns;
+    private final IngredientListBatchRenderer guiHistoryIngredientSlots;
+    @SuppressWarnings("rawtypes")
+    private final List<IIngredientListElement> historyIngredientElements = new ArrayList<>();
+
+    private boolean showHistory;
+
+    public IngredientGridHistoryProvider(boolean enable) {
+        this.enable = enable;
+        this.guiHistoryIngredientSlots = new IngredientListBatchRenderer();
+
+        GLOBAL_HISTORY_CONTAINER.add(this);
+    }
+
+    /**
+     * @see mezz.jei.gui.recipes.RecipesGui#show(IFocus)
+     */
+    public static <V> void onSetFocus(IFocus<V> focus) {
+        for (IngredientGridHistoryProvider historyProvider : GLOBAL_HISTORY_CONTAINER) {
+            if (historyProvider.isEnable()) {
+                historyProvider.addHistoryIngredient(focus.getValue());
+            }
+        }
+    }
+
+    public void addHistoryIngredient(@Nullable Object value) {
+        if (!enable) {
+            return;
+        }
+        if (value == null) {
+            return;
+        }
+
+        Object normalized = getNormalize(Objects.requireNonNull(ingredientRegistry), value);
+        IIngredientListElement<?> ingredient = IngredientListElement.create(
+                normalized,
+                ingredientRegistry.getIngredientHelper(normalized),
+                ingredientRegistry.getIngredientRenderer(normalized),
+                ForgeModIdHelper.getInstance(),
+                ORDER_TRACKER.getOrderIndex(normalized, ingredientRegistry.getIngredientHelper(normalized)));
+
+        historyIngredientElements.removeIf(element -> areIngredientEqual(element.getIngredient(), normalized, HISTORY_MATCH_NBT));
+        historyIngredientElements.add(0, ingredient);
+        if (historyIngredientElements.size() > historySize) {
+            historyIngredientElements.remove(historyIngredientElements.size() - 1);
+        }
+
+        while (historyIngredientElements.size() > USE_ROWS * Config.largestNumColumns) {
+            historyIngredientElements.remove(historyIngredientElements.size() - 1);
+        }
+
+        guiHistoryIngredientSlots.set(0, historyIngredientElements);
+    }
+
+    public void removeElement(int index) {
+        if (!enable) {
+            return;
+        }
+
+        historyIngredientElements.remove(index);
+        guiHistoryIngredientSlots.set(0, historyIngredientElements);
+    }
+
+    // internal methods
+
+    void updateColumns(int columns) {
+        if (!enable) {
+            return;
+        }
+
+        this.columns = columns;
+    }
+
+    void updateHistorySize(int columns) {
+        if (!enable) {
+            return;
+        }
+
+        historySize = columns * USE_ROWS;
+    }
+
+    void clearHistorySlots() {
+        if (!enable) {
+            return;
+        }
+
+        guiHistoryIngredientSlots.clear();
+    }
+
+    boolean updateBoundsExtra(
+            int columns,
+            int rows,
+            int y,
+            int xOffset,
+            Collection<Rectangle> exclusionAreas,
+            IngredientListBatchRenderer guiIngredientSlots) {
+
+        if (!enable) {
+            return false;
+        }
+
+        this.columns = columns;
+        this.historySize = columns * USE_ROWS;
+
+        if (rows >= MIN_ROWS) {
+            rows = rows - USE_ROWS;
+            showHistory = true;
+        } else {
+            showHistory = false;
+        }
+
+        if (!showHistory) {
+            return false;
+        }
+
+        for (int row = 0; row < rows; row++) {
+            List<IngredientListSlot> ingredientRow = new ArrayList<>();
+            int y1 = y + (row * INGREDIENT_HEIGHT);
+            for (int column = 0; column < columns; column++) {
+                int x1 = xOffset + (column * INGREDIENT_WIDTH);
+                IngredientListSlot ingredientListSlot = new IngredientListSlot(x1, y1, INGREDIENT_PADDING);
+                Rectangle stackArea = ingredientListSlot.getArea();
+                final boolean blocked = MathUtil.intersects(exclusionAreas, stackArea);
+                ingredientListSlot.setBlocked(blocked);
+                ingredientRow.add(ingredientListSlot);
+            }
+            guiIngredientSlots.add(ingredientRow);
+        }
+
+        for (int row = 0; row < USE_ROWS; row++) {
+            List<IngredientListSlot> ingredientRow = new ArrayList<>();
+            int y1 = y + ((row + rows) * INGREDIENT_HEIGHT);
+            for (int column = 0; column < columns; column++) {
+                int x1 = xOffset + (column * INGREDIENT_WIDTH);
+                IngredientListSlot ingredientListSlot = new IngredientListSlot(x1, y1, INGREDIENT_PADDING);
+                Rectangle stackArea = ingredientListSlot.getArea();
+                final boolean blocked = MathUtil.intersects(exclusionAreas, stackArea);
+                ingredientListSlot.setBlocked(blocked);
+                ingredientRow.add(ingredientListSlot);
+            }
+            guiHistoryIngredientSlots.add(ingredientRow);
+        }
+
+        guiHistoryIngredientSlots.set(0, historyIngredientElements);
+
+        return true;
+    }
+
+    void drawExtra(Minecraft minecraft) {
+        if (!enable) {
+            return;
+        }
+        if (!showHistory) {
+            return;
+        }
+
+        Rectangle firstRect = guiHistoryIngredientSlots.getAllGuiIngredientSlots().get(0).getArea();
+
+        drawSpillingArea(
+                firstRect.x, firstRect.y,
+                firstRect.width * columns,
+                firstRect.height * USE_ROWS,
+                BACKGROUND_COLOR);
+
+        guiHistoryIngredientSlots.render(minecraft);
+    }
+
+    @SuppressWarnings("rawtypes")
+    void drawTooltipsExtra(Minecraft minecraft, int mouseX, int mouseY) {
+        if (!enable) {
+            return;
+        }
+        if (!showHistory) {
+            return;
+        }
+
+        IngredientRenderer hoveredHistory = guiHistoryIngredientSlots.getHovered(mouseX, mouseY);
+        if (hoveredHistory != null) {
+            hoveredHistory.drawTooltip(minecraft, mouseX, mouseY);
+        }
+    }
+
+    @Nullable
+    IClickedIngredient<?> getIngredientUnderMouseExtra(
+            @Nullable IClickedIngredient<?> result,
+            int mouseX,
+            int mouseY) {
+
+        if (result != null) {
+            return result;
+        }
+        if (!enable) {
+            return null;
+        }
+        if (!showHistory) {
+            return null;
+        }
+
+        ClickedIngredient<?> clickedHistory = guiHistoryIngredientSlots.getIngredientUnderMouse(mouseX, mouseY);
+        if (clickedHistory != null) {
+            clickedHistory.setAllowsCheating();
+        }
+        return clickedHistory;
+    }
+
+    // helper methods
+
+    private static boolean areIngredientEqual(Object ingredient1, Object ingredient2, boolean matchesNbt) {
+        if (ingredient1 == ingredient2) {
+            return true;
+        }
+
+        if (ingredient1.getClass() == ingredient2.getClass()) {
+            IIngredientHelper<Object> ingredientHelper = Objects.requireNonNull(ingredientRegistry).getIngredientHelper(ingredient1);
+            if (matchesNbt) {
+                return ingredientHelper.getUniqueId(ingredient1).equals(ingredientHelper.getUniqueId(ingredient2));
+            }
+            return ingredientHelper.getWildcardId(ingredient1).equals(ingredientHelper.getWildcardId(ingredient2));
+        }
+
+        return false;
+    }
+
+    private static <T> T getNormalize(IIngredientRegistry ingredientRegistry, T ingredient) {
+        IIngredientHelper<T> ingredientHelper = ingredientRegistry.getIngredientHelper(ingredient);
+        T copy = LegacyUtil.getIngredientCopy(ingredient, ingredientHelper);
+        if (copy instanceof ItemStack) {
+            ((ItemStack) copy).setCount(1);
+        } else if (copy instanceof FluidStack) {
+            ((FluidStack) copy).amount = 1000;
+        }
+        return copy;
+    }
+
+    private static void drawSpillingArea(int x, int y, int width, int height, int color) {
+        float alpha = (float) (color >> 24 & 255) / 255f;
+        float red = (float) (color >> 16 & 255) / 255f;
+        float green = (float) (color >> 8 & 255) / 255f;
+        float blue = (float) (color & 255) / 255f;
+
+        GlStateManager.pushMatrix();
+
+        GlStateManager.disableTexture2D();
+        GL11.glEnable(GL11.GL_LINE_STIPPLE);
+        GlStateManager.color(red, green, blue, alpha);
+        GL11.glLineWidth(2F);
+        GL11.glLineStipple(2, (short) 0x00FF);
+
+        GL11.glBegin(GL11.GL_LINE_LOOP);
+
+        GL11.glVertex2i(x, y);
+        GL11.glVertex2i(x + width, y);
+        GL11.glVertex2i(x + width, y + height);
+        GL11.glVertex2i(x, y + height);
+
+        GL11.glEnd();
+
+        GL11.glLineStipple(2, (short) 0xFFFF);
+        GL11.glLineWidth(2F);
+        GL11.glDisable(GL11.GL_LINE_STIPPLE);
+        GlStateManager.enableTexture2D();
+        GlStateManager.color(1F, 1F, 1F, 1F);
+
+        GlStateManager.popMatrix();
+    }
+}

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
@@ -1,5 +1,6 @@
 package mezz.jei.gui.overlay;
 
+import mezz.jei.Internal;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.recipe.IFocus;
@@ -83,16 +84,21 @@ public class IngredientGridHistoryProvider {
         if (value == null) {
             return;
         }
+        if (ignoreIngredient(value)) {
+            return;
+        }
 
-        Object normalized = getNormalize(Objects.requireNonNull(ingredientRegistry), value);
+        Object normalized = normalizeIngredient(Objects.requireNonNull(ingredientRegistry), value);
+        IIngredientHelper<Object> helper = ingredientRegistry.getIngredientHelper(normalized);
+
         IIngredientListElement<?> ingredient = IngredientListElement.create(
                 normalized,
-                ingredientRegistry.getIngredientHelper(normalized),
+                helper,
                 ingredientRegistry.getIngredientRenderer(normalized),
                 ForgeModIdHelper.getInstance(),
-                ORDER_TRACKER.getOrderIndex(normalized, ingredientRegistry.getIngredientHelper(normalized)));
+                ORDER_TRACKER.getOrderIndex(normalized, helper));
 
-        historyIngredientElements.removeIf(element -> areIngredientEqual(element.getIngredient(), normalized, HISTORY_MATCH_NBT));
+        historyIngredientElements.removeIf(element -> areIngredientsEqual(element.getIngredient(), normalized, HISTORY_MATCH_NBT));
         historyIngredientElements.add(0, ingredient);
         if (historyIngredientElements.size() > historySize) {
             historyIngredientElements.remove(historyIngredientElements.size() - 1);
@@ -258,7 +264,7 @@ public class IngredientGridHistoryProvider {
 
     // helper methods
 
-    private static boolean areIngredientEqual(Object ingredient1, Object ingredient2, boolean matchesNbt) {
+    private static boolean areIngredientsEqual(Object ingredient1, Object ingredient2, boolean matchesNbt) {
         if (ingredient1 == ingredient2) {
             return true;
         }
@@ -274,7 +280,11 @@ public class IngredientGridHistoryProvider {
         return false;
     }
 
-    private static <T> T getNormalize(IIngredientRegistry ingredientRegistry, T ingredient) {
+    private static boolean ignoreIngredient(Object ingredient) {
+        return Internal.getHelpers().getIngredientBlacklist().isIngredientBlacklisted(ingredient);
+    }
+
+    private static <T> T normalizeIngredient(IIngredientRegistry ingredientRegistry, T ingredient) {
         IIngredientHelper<T> ingredientHelper = ingredientRegistry.getIngredientHelper(ingredient);
         T copy = LegacyUtil.getIngredientCopy(ingredient, ingredientHelper);
         if (copy instanceof ItemStack) {

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
@@ -117,7 +117,7 @@ public class IngredientGridHistoryProvider {
 
     // internal methods
 
-    void updateColumns(int columns) {
+    public void updateColumns(int columns) {
         if (!enabled) {
             return;
         }
@@ -125,7 +125,7 @@ public class IngredientGridHistoryProvider {
         this.columns = columns;
     }
 
-    void clearHistorySlots() {
+    public void clearHistorySlots() {
         if (!enabled) {
             return;
         }
@@ -133,7 +133,7 @@ public class IngredientGridHistoryProvider {
         guiHistoryIngredientSlots.clear();
     }
 
-    boolean updateBoundsExtra(
+    public boolean updateBoundsExtra(
             int columns,
             int rows,
             int y,
@@ -191,7 +191,7 @@ public class IngredientGridHistoryProvider {
         return true;
     }
 
-    void drawExtra(Minecraft minecraft) {
+    public void drawExtra(Minecraft minecraft) {
         if (!enabled) {
             return;
         }
@@ -211,7 +211,7 @@ public class IngredientGridHistoryProvider {
     }
 
     @SuppressWarnings("rawtypes")
-    void drawTooltipsExtra(Minecraft minecraft, int mouseX, int mouseY) {
+    public void drawTooltipsExtra(Minecraft minecraft, int mouseX, int mouseY) {
         if (!enabled) {
             return;
         }
@@ -226,7 +226,7 @@ public class IngredientGridHistoryProvider {
     }
 
     @Nullable
-    IClickedIngredient<?> getIngredientUnderMouseExtra(
+    public IClickedIngredient<?> getIngredientUnderMouseExtra(
             @Nullable IClickedIngredient<?> result,
             int mouseX,
             int mouseY) {

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridHistoryProvider.java
@@ -44,10 +44,10 @@ public class IngredientGridHistoryProvider {
     public static final int BACKGROUND_COLOR = 0xee555555;
     public static final boolean HISTORY_MATCH_NBT = true;
 
-    private final boolean enable;
+    private final boolean enabled;
 
-    public boolean isEnable() {
-        return enable;
+    public boolean isEnabled() {
+        return enabled;
     }
 
     private int historySize;
@@ -58,8 +58,8 @@ public class IngredientGridHistoryProvider {
 
     private boolean showHistory;
 
-    public IngredientGridHistoryProvider(boolean enable) {
-        this.enable = enable;
+    public IngredientGridHistoryProvider(boolean enabled) {
+        this.enabled = enabled;
         this.guiHistoryIngredientSlots = new IngredientListBatchRenderer();
 
         GLOBAL_HISTORY_CONTAINER.add(this);
@@ -70,14 +70,14 @@ public class IngredientGridHistoryProvider {
      */
     public static <V> void onSetFocus(IFocus<V> focus) {
         for (IngredientGridHistoryProvider historyProvider : GLOBAL_HISTORY_CONTAINER) {
-            if (historyProvider.isEnable()) {
+            if (historyProvider.isEnabled()) {
                 historyProvider.addHistoryIngredient(focus.getValue());
             }
         }
     }
 
     public void addHistoryIngredient(@Nullable Object value) {
-        if (!enable) {
+        if (!enabled) {
             return;
         }
         if (value == null) {
@@ -106,7 +106,7 @@ public class IngredientGridHistoryProvider {
     }
 
     public void removeElement(int index) {
-        if (!enable) {
+        if (!enabled) {
             return;
         }
 
@@ -117,7 +117,7 @@ public class IngredientGridHistoryProvider {
     // internal methods
 
     void updateColumns(int columns) {
-        if (!enable) {
+        if (!enabled) {
             return;
         }
 
@@ -125,7 +125,7 @@ public class IngredientGridHistoryProvider {
     }
 
     void updateHistorySize(int columns) {
-        if (!enable) {
+        if (!enabled) {
             return;
         }
 
@@ -133,7 +133,7 @@ public class IngredientGridHistoryProvider {
     }
 
     void clearHistorySlots() {
-        if (!enable) {
+        if (!enabled) {
             return;
         }
 
@@ -148,7 +148,7 @@ public class IngredientGridHistoryProvider {
             Collection<Rectangle> exclusionAreas,
             IngredientListBatchRenderer guiIngredientSlots) {
 
-        if (!enable) {
+        if (!enabled) {
             return false;
         }
 
@@ -200,7 +200,7 @@ public class IngredientGridHistoryProvider {
     }
 
     void drawExtra(Minecraft minecraft) {
-        if (!enable) {
+        if (!enabled) {
             return;
         }
         if (!showHistory) {
@@ -220,7 +220,7 @@ public class IngredientGridHistoryProvider {
 
     @SuppressWarnings("rawtypes")
     void drawTooltipsExtra(Minecraft minecraft, int mouseX, int mouseY) {
-        if (!enable) {
+        if (!enabled) {
             return;
         }
         if (!showHistory) {
@@ -242,7 +242,7 @@ public class IngredientGridHistoryProvider {
         if (result != null) {
             return result;
         }
-        if (!enable) {
+        if (!enabled) {
             return null;
         }
         if (!showHistory) {

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
@@ -40,7 +40,7 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 	private Rectangle area = new Rectangle();
 
 	public IngredientGridWithNavigation(IIngredientGridSource ingredientSource, GuiScreenHelper guiScreenHelper, GridAlignment alignment) {
-		this.ingredientGrid = new IngredientGrid(new IngredientListBatchRenderer(), alignment, true);
+		this.ingredientGrid = new IngredientGrid(new IngredientListBatchRenderer(), alignment, Config.enableHistoryPanel() && !Config.isHistoryPanelOnLeft());
 		this.ingredientSource = ingredientSource;
 		this.guiScreenHelper = guiScreenHelper;
 		this.pageDelegate = new IngredientGridPaged();

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
@@ -40,7 +40,7 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 	private Rectangle area = new Rectangle();
 
 	public IngredientGridWithNavigation(IIngredientGridSource ingredientSource, GuiScreenHelper guiScreenHelper, GridAlignment alignment) {
-		this.ingredientGrid = new IngredientGrid(new IngredientListBatchRenderer(), alignment);
+		this.ingredientGrid = new IngredientGrid(new IngredientListBatchRenderer(), alignment, true);
 		this.ingredientSource = ingredientSource;
 		this.guiScreenHelper = guiScreenHelper;
 		this.pageDelegate = new IngredientGridPaged();

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGrid.java
@@ -21,7 +21,7 @@ public class BookmarkGrid extends IngredientGrid {
     private Rectangle area = new Rectangle();
 
     public BookmarkGrid(GridAlignment alignment, BookmarkGroupOrganizer groupOrganizer) {
-        super(new BookmarkListBatchRenderer(groupOrganizer), alignment);
+        super(new BookmarkListBatchRenderer(groupOrganizer), alignment, false);
         this.alignment = alignment;
     }
 

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGrid.java
@@ -21,10 +21,11 @@ public class BookmarkGrid extends IngredientGrid {
     private Rectangle area = new Rectangle();
 
     public BookmarkGrid(GridAlignment alignment, BookmarkGroupOrganizer groupOrganizer) {
-        super(new BookmarkListBatchRenderer(groupOrganizer), alignment, false);
+        super(new BookmarkListBatchRenderer(groupOrganizer), alignment, Config.enableHistoryPanel() && Config.isHistoryPanelOnLeft());
         this.alignment = alignment;
     }
 
+    @Override
     public boolean updateBounds(Rectangle availableArea, int minWidth, Collection<Rectangle> exclusionAreas) {
         final int columns = Math.min(availableArea.width / INGREDIENT_WIDTH, Config.getMaxColumns());
         final int rows = availableArea.height / INGREDIENT_HEIGHT;
@@ -44,23 +45,38 @@ public class BookmarkGrid extends IngredientGrid {
         this.area = new Rectangle(x, y, width, height);
         this.guiIngredientSlots.clear();
 
+        if (historyProvider.isEnabled()) {
+            historyProvider.updateColumns(columns);
+            historyProvider.clearHistorySlots();
+        }
+
         if (rows == 0 || columns < Config.smallestNumColumns) {
             return false;
         }
 
-        for (int row = 0; row < rows; row++) {
-            int y1 = y + (row * INGREDIENT_HEIGHT);
-            List<IngredientListSlot> ingredientRow = new ArrayList<>();
-            for (int column = 0; column < columns; column++) {
-                int x1 = xOffset + (column * INGREDIENT_WIDTH);
-                IngredientListSlot ingredientListSlot = new IngredientListSlot(x1, y1, INGREDIENT_PADDING);
-                Rectangle stackArea = ingredientListSlot.getArea();
-                final boolean blocked = MathUtil.intersects(exclusionAreas, stackArea);
-                ingredientListSlot.setBlocked(blocked);
-                ingredientRow.add(ingredientListSlot);
+        if (!historyProvider.updateBoundsExtra(
+                columns,
+                rows,
+                y,
+                xOffset,
+                exclusionAreas,
+                this.guiIngredientSlots)) {
+
+            for (int row = 0; row < rows; row++) {
+                int y1 = y + (row * INGREDIENT_HEIGHT);
+                List<IngredientListSlot> ingredientRow = new ArrayList<>();
+                for (int column = 0; column < columns; column++) {
+                    int x1 = xOffset + (column * INGREDIENT_WIDTH);
+                    IngredientListSlot ingredientListSlot = new IngredientListSlot(x1, y1, INGREDIENT_PADDING);
+                    Rectangle stackArea = ingredientListSlot.getArea();
+                    final boolean blocked = MathUtil.intersects(exclusionAreas, stackArea);
+                    ingredientListSlot.setBlocked(blocked);
+                    ingredientRow.add(ingredientListSlot);
+                }
+                this.guiIngredientSlots.add(ingredientRow);
             }
-            this.guiIngredientSlots.add(ingredientRow);
         }
+
         return true;
     }
 

--- a/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -15,6 +15,7 @@ import mezz.jei.gui.TooltipRenderer;
 import mezz.jei.gui.elements.DrawableNineSliceTexture;
 import mezz.jei.gui.elements.GuiIconButtonSmall;
 import mezz.jei.gui.ingredients.GuiIngredient;
+import mezz.jei.gui.overlay.IngredientGridHistoryProvider;
 import mezz.jei.gui.overlay.IngredientListOverlay;
 import mezz.jei.ingredients.IngredientRegistry;
 import mezz.jei.input.ClickedIngredient;
@@ -417,6 +418,8 @@ public class RecipesGui extends GuiScreen implements IRecipesGui, IShowsRecipeFo
 		if (logic.setFocus(focus)) {
 			open();
 		}
+
+		IngredientGridHistoryProvider.onSetFocus(focus);
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/ingredients/IngredientListElementFactory.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientListElementFactory.java
@@ -15,7 +15,7 @@ import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.startup.IModIdHelper;
 
 public final class IngredientListElementFactory {
-	private static final IngredientOrderTracker ORDER_TRACKER = new IngredientOrderTracker();
+	public static final IngredientOrderTracker ORDER_TRACKER = new IngredientOrderTracker();
 
 	private IngredientListElementFactory() {
 	}

--- a/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
+++ b/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
@@ -205,21 +205,28 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 		int total = ingredients.size();
 		int shown = Math.min(total, MAX_VISIBLE);
 		int overflow = total - shown;
+		int overflowPadding = 0;
 		int numRows = shown <= COLS ? 1 : shown <= COLS * 2 ? 2 : 3;
 		int gridCols = numRows > 1 ? COLS : shown;
 		int gridW = gridCols * SLOT;
 		int gridH = numRows * SLOT;
 
+		if (overflow > 0) {
+			String overStr = "+" + overflow;
+			int overWidth = font.getStringWidth(overStr) + 2;
+			overflowPadding = Math.max(0, overWidth - SLOT);
+		}
+
 		String header = TextFormatting.GOLD + collapsedStack.getDisplayName()
-			+ TextFormatting.GRAY + " (" + total + " items)";
+				+ TextFormatting.GRAY + " (" + total + " items)";
 		// In OPEN_GROUP mode, alt+click uses first item; show that as the hint.
 		// In FIRST_ITEM mode, alt+click expands; show that instead.
 		String hint = TextFormatting.YELLOW + Translator.translateToLocal(
-			Config.getCollapsedClickAction() == CollapsedClickAction.OPEN_GROUP
-				? "hei.tooltip.collapsed.expand.firstItem"
-				: "hei.tooltip.collapsed.expand");
+				Config.getCollapsedClickAction() == CollapsedClickAction.OPEN_GROUP
+						? "hei.tooltip.collapsed.expand.firstItem"
+						: "hei.tooltip.collapsed.expand");
 
-		int tw = Math.max(Math.max(font.getStringWidth(header), font.getStringWidth(hint)), gridW);
+		int tw = Math.max(Math.max(font.getStringWidth(header), font.getStringWidth(hint)), gridW) + overflowPadding;
 		int th = 12 + gridH + 10;
 
 		ScaledResolution sr = new ScaledResolution(minecraft);
@@ -237,15 +244,15 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 		// Draw tooltip background (MC-style dark purple box with gradient border)
 		final int z = 300;
 		int bg = 0xF0100010, bs = 0x505000FF, be = (bs & 0xFEFEFE) >> 1 | (bs & 0xFF000000);
-		GuiUtils.drawGradientRect(z, tx-3, ty-4, tx+tw+3, ty-3, bg, bg);
-		GuiUtils.drawGradientRect(z, tx-3, ty+th+3, tx+tw+3, ty+th+4, bg, bg);
-		GuiUtils.drawGradientRect(z, tx-3, ty-3, tx+tw+3, ty+th+3, bg, bg);
-		GuiUtils.drawGradientRect(z, tx-4, ty-3, tx-3, ty+th+3, bg, bg);
-		GuiUtils.drawGradientRect(z, tx+tw+3, ty-3, tx+tw+4, ty+th+3, bg, bg);
-		GuiUtils.drawGradientRect(z, tx-3, ty-2, tx-2, ty+th+2, bs, be);
-		GuiUtils.drawGradientRect(z, tx+tw+2, ty-2, tx+tw+3, ty+th+2, bs, be);
-		GuiUtils.drawGradientRect(z, tx-3, ty-3, tx+tw+3, ty-2, bs, bs);
-		GuiUtils.drawGradientRect(z, tx-3, ty+th+2, tx+tw+3, ty+th+3, be, be);
+		GuiUtils.drawGradientRect(z, tx - 3, ty - 4, tx + tw + 3, ty - 3, bg, bg);
+		GuiUtils.drawGradientRect(z, tx - 3, ty + th + 3, tx + tw + 3, ty + th + 4, bg, bg);
+		GuiUtils.drawGradientRect(z, tx - 3, ty - 3, tx + tw + 3, ty + th + 3, bg, bg);
+		GuiUtils.drawGradientRect(z, tx - 4, ty - 3, tx - 3, ty + th + 3, bg, bg);
+		GuiUtils.drawGradientRect(z, tx + tw + 3, ty - 3, tx + tw + 4, ty + th + 3, bg, bg);
+		GuiUtils.drawGradientRect(z, tx - 3, ty - 2, tx - 2, ty + th + 2, bs, be);
+		GuiUtils.drawGradientRect(z, tx + tw + 2, ty - 2, tx + tw + 3, ty + th + 2, bs, be);
+		GuiUtils.drawGradientRect(z, tx - 3, ty - 3, tx + tw + 3, ty - 2, bs, bs);
+		GuiUtils.drawGradientRect(z, tx - 3, ty + th + 2, tx + tw + 3, ty + th + 3, be, be);
 
 		// Title
 		font.drawStringWithShadow(header, tx, ty, -1);
@@ -265,8 +272,10 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 			if (ing instanceof ItemStack) {
 				renderItem.renderItemAndEffectIntoGUI((ItemStack) ing, ix, iy);
 			} else {
-				try { renderIngredient(minecraft, ix, iy, element); }
-				catch (RuntimeException | LinkageError ignored) {}
+				try {
+					renderIngredient(minecraft, ix, iy, element);
+				} catch (RuntimeException | LinkageError ignored) {
+				}
 			}
 		}
 		RenderHelper.disableStandardItemLighting();

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -404,8 +404,11 @@ public class IngredientListBatchRenderer {
         return collapsedStackIndexed;
     }
 
+    static int counter = 0;
+
     public void render(Minecraft minecraft) {
         if (allowBuffering && !Config.isEditModeEnabled() && Config.bufferIngredientRenders() && OpenGlHelper.isFramebufferEnabled()) {
+            counter++;
             if (framebuffer == null) {
                 framebuffer = new Framebuffer(minecraft.displayWidth, minecraft.displayHeight, true);
                 framebuffer.framebufferColor[0] = 0.0F;
@@ -413,6 +416,7 @@ public class IngredientListBatchRenderer {
                 framebuffer.framebufferColor[2] = 0.0F;
             }
             if (refreshBuffer) {
+                Log.get().info("debug: " + counter);
                 framebuffer.createBindFramebuffer(minecraft.displayWidth, minecraft.displayHeight);
                 framebuffer.framebufferClear();
                 framebuffer.bindFramebuffer(false);

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -404,11 +404,8 @@ public class IngredientListBatchRenderer {
         return collapsedStackIndexed;
     }
 
-    static int counter = 0;
-
     public void render(Minecraft minecraft) {
         if (allowBuffering && !Config.isEditModeEnabled() && Config.bufferIngredientRenders() && OpenGlHelper.isFramebufferEnabled()) {
-            counter++;
             if (framebuffer == null) {
                 framebuffer = new Framebuffer(minecraft.displayWidth, minecraft.displayHeight, true);
                 framebuffer.framebufferColor[0] = 0.0F;
@@ -416,7 +413,6 @@ public class IngredientListBatchRenderer {
                 framebuffer.framebufferColor[2] = 0.0F;
             }
             if (refreshBuffer) {
-                Log.get().info("debug: " + counter);
                 framebuffer.createBindFramebuffer(minecraft.displayWidth, minecraft.displayHeight);
                 framebuffer.framebufferClear();
                 framebuffer.bindFramebuffer(false);

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -189,6 +189,12 @@ config.jei.misc.hideBottomRightCornerConfigButton.comment=Whether to hide the bo
 config.jei.misc.hideBottomLeftCornerBookmarkButton=Hide Bottom-Left Corner Bookmark Button
 config.jei.misc.hideBottomLeftCornerBookmarkButton.comment=Whether to hide the bottom-left corner bookmark button
 
+config.jei.misc.enableHistoryPanel=Enable History Panel
+config.jei.misc.enableHistoryPanel.comment=Whether to enable the history panel
+
+config.jei.misc.isHistoryPanelOnLeft=Is History Panel On Left
+config.jei.misc.isHistoryPanelOnLeft.comment=The history panel can be on either the left or the right (true=left, false=right)
+
 config.hei.collapsible=Collapsible Groups
 config.hei.collapsible.comment=Options for collapsing groups of ingredients into a single slot in the ingredient list.
 config.hei.collapsible.collapsibleGroupsEnabled=Enable Collapsible Groups


### PR DESCRIPTION
## Fix Padding
<img width="1282" height="521" alt="Snipaste_2026-04-09_15-11-34" src="https://github.com/user-attachments/assets/f6e71537-4904-46c1-85b2-7f90a5a74ff0" />
<img width="1322" height="512" alt="Snipaste_2026-04-09_15-00-39" src="https://github.com/user-attachments/assets/b32c5132-a5b8-4085-b0fd-9afe88c607e1" />

## JEI History
<img width="565" height="683" alt="image" src="https://github.com/user-attachments/assets/2d25aaad-70c0-4968-8362-1b2f05dc22e4" />

> Note:
> My implementation is still compatible with JEI-Utilities. No crash. It will disable itself when JEI-Utilities is installed since it modified the ctor that JEI-Utilities overrides
> ```java
>	public IngredientGrid(GridAlignment alignment) { // Left in for compatibility with JEI Utilities
>		this(new IngredientListBatchRenderer(), alignment, enableHistory:false);
>	}
> ```

**Concerns**:<br>
Firstly,
```java
@Override
public <V> void show(IFocus<V> focus) {
	focus = Focus.check(focus);

	if (logic.setFocus(focus)) {
		open();
	}

	IngredientGridHistoryProvider.onSetFocus(focus);
}
```
I post an event in `RecipesGui#show` to notify enabled history providers, which looks pretty inelegant. JEI-Utilities does ASM on this.

Secondly, in order to notify all history providers
```java
private static final List<IngredientGridHistoryProvider> GLOBAL_HISTORY_CONTAINER = new ArrayList<>();

public IngredientGridHistoryProvider(boolean enable) {
    this.enable = enable;
    this.guiHistoryIngredientSlots = new IngredientListBatchRenderer();

    GLOBAL_HISTORY_CONTAINER.add(this);
}
```
I created a static field to record all history providers, which looks rough too, but accessing history providers via a `Internal.getRuntime()...` chain doesn't look good either.

