### PR TITLE
Fix color material rendering issue on collapsed groups.

### DIFF
--- a/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
+++ b/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
@@ -136,6 +136,7 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 	private static void renderElementAt(Minecraft minecraft, IIngredientListElement<?> element, int x, int y, float scale) {
 		Object ingredient = element.getIngredient();
 		try {
+			RenderHelper.enableGUIStandardItemLighting();
 			GlStateManager.pushMatrix();
 			GlStateManager.translate(x, y, 0);
 			GlStateManager.scale(scale, scale, scale);


### PR DESCRIPTION
Fixes color material appearing as grayscale on collapsed groups if rendered after enchanted books which disables standard item rendering.