### PR TITLE
Add Ghost Ingredient Quick Move API Method

### DIFF
--- a/src/api/java/mezz/jei/api/gui/IGhostIngredientHandler.java
+++ b/src/api/java/mezz/jei/api/gui/IGhostIngredientHandler.java
@@ -38,6 +38,20 @@ public interface IGhostIngredientHandler<T extends GuiScreen> {
 		return true;
 	}
 
+	/**
+	 * Called when a player starts to move a ghost ingredient while holding SHIFT.
+	 * In most cases this should insert the ingredient into one of the highlighted targets.
+	 * This is called before {@link #getTargets(GuiScreen, Object, boolean)} starts
+	 * the drag process, and if this returns true the normal logic will not be run.
+	 *
+	 * @return true if some operation occurred and the normal targeting
+	 * and drag logic should be skipped
+	 * @since HEI 4.30.2
+	 */
+	default <I> boolean quickMove(T gui, I ingredient) {
+		return false;
+	}
+
 	interface Target<I> extends Consumer<I> {
 		/**
 		 * @return the area (in screen coordinates) where the ingredient can be dropped.

--- a/src/main/java/mezz/jei/gui/ghost/GhostIngredientDragManager.java
+++ b/src/main/java/mezz/jei/gui/ghost/GhostIngredientDragManager.java
@@ -141,6 +141,12 @@ public class GhostIngredientDragManager {
 
     public <T extends GuiScreen, V> boolean handleClickGhostIngredient(IGhostIngredientHandler<T> handler, T currentScreen, IClickedIngredient<V> clicked) {
         V ingredient = clicked.getValue();
+        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) {
+            if (handler.quickMove(currentScreen, ingredient)) {
+                clicked.onClickHandled();
+                return true;
+            }
+        }
         List<IGhostIngredientHandler.Target<V>> targets = handler.getTargets(currentScreen, ingredient, true);
         if (!targets.isEmpty()) {
             IIngredientRenderer<V> ingredientRenderer = ingredientRegistry.getIngredientRenderer(ingredient);

--- a/src/main/java/mezz/jei/plugins/jei/debug/DebugGhostIngredientHandler.java
+++ b/src/main/java/mezz/jei/plugins/jei/debug/DebugGhostIngredientHandler.java
@@ -41,6 +41,13 @@ public class DebugGhostIngredientHandler<T extends GuiContainer> implements IGho
 		Log.get().info("Ghost Ingredient Handling Complete");
 	}
 
+	@Override
+	public <I> boolean quickMove(T gui, I ingredient) {
+		IIngredientHelper<I> ingredientHelper = Internal.getIngredientRegistry().getIngredientHelper(ingredient);
+		Log.get().info("Attempt to Quick Move Ghost Ingredient {}", ingredientHelper.getErrorInfo(ingredient));
+		return true;
+	}
+
 	private static class DebugInfoTarget<I> implements IGhostIngredientHandler.Target<I> {
 		private final String message;
 		private final Rectangle rectangle;


### PR DESCRIPTION
changes in this PR:
- add `quickMove` to `IGhostIngredientHandler`, which is called when a valid ghost ingredient is shift+clicked. if it returns `true`, the normal logic will be skipped.

this just adds to the api - if `quickMove` is not overridden, no difference in functionality will be observed.

requested by and resolves #169