### PR TITLE
Fix collapsed group order & explicit search returns

### DIFF
--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -7,8 +7,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
 import mezz.jei.Internal;
 import mezz.jei.ingredients.group.CollapsibleGroup;
 import mezz.jei.ingredients.group.CollapsedGroupIngredient;
@@ -65,9 +66,10 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 	@Nullable private Multimap<IIngredientListElement<?>, CollapsibleGroup> groupMembershipCache = null;
 	/**
 	 * Reverse of {@link #groupMembershipCache}: maps each {@link CollapsibleGroup} to the
-	 * visible elements that belong to it. Built alongside {@code groupMembershipCache} via
-	 * {@link Multimaps#invertFrom} at no extra cost; used by {@link #withGroupNameMatches}
-	 * to look up group members directly instead of scanning all visible ingredients.
+	 * visible elements that belong to it. Built directly during the sorted
+	 * {@code allVisibleIngredientsCache} traversal to preserve sort order; used by
+	 * {@link #withGroupNameMatches} to look up group members directly instead of scanning
+	 * all visible ingredients.
 	 */
 	@Nullable private Multimap<CollapsibleGroup, IIngredientListElement<?>> groupToElementsCache = null;
 
@@ -162,20 +164,29 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 					}
 				}
 			}
+			// Build groupToElementsCache directly during the sorted traversal so its
+			// per-group value order matches allVisibleIngredientsCache's sort order.
+			// Multimaps.invertFrom over a HashMultimap would lose that order because
+			// HashMultimap.entries() iterates keys in hash order, not insertion order.
+			SetMultimap<CollapsibleGroup, IIngredientListElement<?>> gtoc = LinkedHashMultimap.create();
 			for (IIngredientListElement element : allVisibleIngredientsCache) {
 				String uid = element.getIngredientHelper().getUniqueId(element.getIngredient());
 				Collection<CollapsibleGroup> uidGroups = uids.get(uid);
 				if (!uidGroups.isEmpty()) {
 					groupMembershipCache.putAll(element, uidGroups);
+					for (CollapsibleGroup group : uidGroups) {
+						gtoc.put(group, element);
+					}
 				}
 				for (Map.Entry<String, CollapsibleGroup> entry : wildcardEntries) {
 					String prefix = entry.getKey();
 					if (uid.equals(prefix) || uid.startsWith(prefix + ":")) {
 						groupMembershipCache.put(element, entry.getValue());
+						gtoc.put(entry.getValue(), element);
 					}
 				}
 			}
-			groupToElementsCache = Multimaps.invertFrom(groupMembershipCache, HashMultimap.create());
+			groupToElementsCache = gtoc;
 
 			for (CollapsibleGroup group : groups.values()) {
 				Collection<IIngredientListElement<?>> groupElements = groupToElementsCache.get(group);

--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -474,7 +474,23 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 			}
 		}
 
-		result.removeIf(obj -> obj instanceof CollapsedGroupIngredient && ((CollapsedGroupIngredient) obj).isFilterEmpty());
+		// Remove empty groups and deduplicate size-1 groups that share the same single element.
+		// The set tracks the first size-1 group element seen; later duplicates are dropped.
+		Set<IIngredientListElement<?>> seenSingles = new ObjectOpenHashSet<>();
+		result.removeIf(obj -> {
+			if (!(obj instanceof CollapsedGroupIngredient)) {
+				return false;
+			}
+			CollapsedGroupIngredient cg = (CollapsedGroupIngredient) obj;
+			if (cg.isFilterEmpty()) {
+				return true;
+			}
+			List<IIngredientListElement<?>> fi = cg.getFilterIngredients();
+			if (fi.size() == 1) {
+				return !seenSingles.add(fi.get(0));
+			}
+			return false;
+		});
 		return result;
 	}
 

--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -383,28 +383,25 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 	}
 
 	/**
-	 * Augments a filtered ingredient list so that every group relevant to the current search
-	 * is represented by its full member set. A group is relevant if:
-	 *   1. its display name contains the filter text, OR
-	 *   2. at least one of its members already appears in the base results.
-	 *
-	 * This ensures that searching "diamond" surfaces the complete "Helmets" group (not just
-	 * the diamond helmet alone) so that {@link #collapse} can produce a proper multi-item
-	 * group token rather than a degenerate 1-item one.
+	 * Augments a filtered ingredient list with any groups whose display name matches the
+	 * search text, so that typing "wool" surfaces the entire Wool group even though none of
+	 * the individual wool variants mention "wool" in their item name.
+	 * <p>
+	 * We deliberately only expand on group-name match, not on member match. Expanding on
+	 * member match would cause e.g. searching "orange" to pull in the full 16-item Wool
+	 * group when the user only wants the orange wool item.
 	 */
 	private List<IIngredientListElement<?>> withGroupNameMatches(List<IIngredientListElement<?>> baseList, String filterText) {
 		Multimap<CollapsibleGroup, IIngredientListElement<?>> groupToElements = getGroupToElements();
-		Multimap<IIngredientListElement<?>, CollapsibleGroup> membership = getGroupMembership();
 
-		// Collect every group that is relevant to this search
+		// Collect groups whose display name matches the search text.
+		// We intentionally do NOT expand groups just because a member matched — that produced
+		// "full group" results when the user typed e.g. "orange", expecting individual items.
 		Set<CollapsibleGroup> groupsToExpand = new ObjectOpenHashSet<>();
 		for (CollapsibleGroup group : Internal.getCollapsedGroupRegistry().getAllGroups().values()) {
 			if (Translator.toLowercaseWithLocale(group.getIngredient().getDisplayName()).contains(filterText)) {
 				groupsToExpand.add(group);
 			}
-		}
-		for (IIngredientListElement<?> element : baseList) {
-			groupsToExpand.addAll(membership.get(element));
 		}
 
 		if (groupsToExpand.isEmpty()) {

--- a/src/main/java/mezz/jei/ingredients/group/CollapsedGroupIngredient.java
+++ b/src/main/java/mezz/jei/ingredients/group/CollapsedGroupIngredient.java
@@ -122,8 +122,18 @@ public class CollapsedGroupIngredient implements IIngredientListElement<Collapse
 		filterElements.clear();
 	}
 
+	/**
+	 * Returns the ingredient list that should be displayed in the current context.
+	 * When a search filter is active ({@code filterElements} is non-empty), returns
+	 * only the matched subset so the count badge and icons reflect the search results.
+	 * Falls back to the full stable list when no filter is applied (e.g. bookmarks).
+	 */
+	public List<IIngredientListElement<?>> getDisplayIngredients() {
+		return filterElements.isEmpty() ? elements : filterElements;
+	}
+
 	public int size() {
-		return elements.size();
+		return getDisplayIngredients().size();
 	}
 
 	public boolean isEmpty() {

--- a/src/main/java/mezz/jei/ingredients/group/CollapsibleGroupRegistry.java
+++ b/src/main/java/mezz/jei/ingredients/group/CollapsibleGroupRegistry.java
@@ -101,6 +101,11 @@ public class CollapsibleGroupRegistry implements ICollapsibleGroupRegistry {
         if (expandKeyDown) {
             CollapsedGroupRenderer collapsedHovered = renderer.getHoveredCollapsed(mouseX, mouseY);
             if (collapsedHovered != null) {
+                // If the search has filtered this group down to a single item, don't expand —
+                // let the click fall through so InputHandler treats it as clicking the item directly.
+                if (collapsedHovered.getCollapsedStack().size() == 1) {
+                    return false;
+                }
                 collapsedHovered.getCollapsedStack().toggleExpanded();
                 Internal.getIngredientFilter().notifyCollapsedStateChanged();
                 return true;

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -8,6 +8,7 @@ import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.transfer.IAutocraftingHandler;
 import mezz.jei.bookmarks.BookmarkItem;
 import mezz.jei.bookmarks.BookmarkList;
+import mezz.jei.ingredients.group.CollapsedGroupIngredient;
 import mezz.jei.config.Config;
 import mezz.jei.config.IngredientBlacklistType;
 import mezz.jei.config.KeyBindings;
@@ -382,6 +383,11 @@ public class InputHandler {
                 return false;
             }
             return layout.addToBookmarks();
+        }
+
+        // Don't allow bookmarking collapsed groups directly — only individual items.
+        if (value instanceof CollapsedGroupIngredient) {
+            return false;
         }
 
         return bookmarkList.add(new BookmarkItem<>(value));

--- a/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
+++ b/src/main/java/mezz/jei/render/CollapsedGroupRenderer.java
@@ -78,7 +78,7 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 	 * Count badge is drawn at 0.75× scale in orange in the bottom-right corner.
 	 */
 	private static void renderAt(Minecraft minecraft, CollapsedGroupIngredient ingredient, int x, int y) {
-		List<IIngredientListElement<?>> ingredients = ingredient.getIngredients();
+		List<IIngredientListElement<?>> ingredients = ingredient.getDisplayIngredients();
 		if (ingredients.isEmpty()) {
 			return;
 		}
@@ -188,7 +188,7 @@ public class CollapsedGroupRenderer implements IIngredientRenderer<CollapsedGrou
 	}
 
 	public void drawTooltip(Minecraft minecraft, int mouseX, int mouseY) {
-		List<IIngredientListElement<?>> ingredients = collapsedStack.getIngredients();
+		List<IIngredientListElement<?>> ingredients = collapsedStack.getDisplayIngredients();
 		if (ingredients.isEmpty()) return;
 
 		// Single-item group (e.g. search filtered to one result): show the item's native tooltip

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -169,6 +169,10 @@ public class IngredientListBatchRenderer {
                         displayItems.add(element);
                         itemToCollapsed.put(element, collapsed);
                     }
+                } else if (collapsed.size() == 1) {
+                    // Single-item group: render as a plain ingredient slot without collapsed visuals.
+                    // Not tracked in itemToCollapsed so clicks/hover treat it as a normal item.
+                    displayItems.add(collapsed.getDisplayIngredients().get(0));
                 } else {
                     // Collapsed: add the CollapsedStack itself as a single display item
                     displayItems.add(collapsed);

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -164,10 +164,16 @@ public class IngredientListBatchRenderer {
             if (obj instanceof CollapsedGroupIngredient) {
                 CollapsedGroupIngredient collapsed = (CollapsedGroupIngredient) obj;
                 if (collapsed.isExpanded()) {
-                    // Expanded: add each ingredient individually, track which belong to this group
-                    for (IIngredientListElement<?> element : collapsed.getFilterIngredients()) {
-                        displayItems.add(element);
-                        itemToCollapsed.put(element, collapsed);
+                    List<IIngredientListElement<?>> filterIngredients = collapsed.getFilterIngredients();
+                    if (filterIngredients.size() == 1) {
+                        // Expanded but filtered to a single item: treat as a plain slot, no group border.
+                        displayItems.add(filterIngredients.get(0));
+                    } else {
+                        // Expanded: add each ingredient individually, track which belong to this group
+                        for (IIngredientListElement<?> element : filterIngredients) {
+                            displayItems.add(element);
+                            itemToCollapsed.put(element, collapsed);
+                        }
                     }
                 } else if (collapsed.size() == 1) {
                     // Single-item group: render as a plain ingredient slot without collapsed visuals.

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -298,6 +298,13 @@ public class IngredientListBatchRenderer {
         // Check collapsed renderers first
         CollapsedGroupRenderer collapsedHovered = getHoveredCollapsed(mouseX, mouseY);
         if (collapsedHovered != null) {
+            // If the search has filtered this group to a single item, act as if the user
+            // clicked that item directly — no expand step needed.
+            CollapsedGroupIngredient stack = collapsedHovered.getCollapsedStack();
+            if (stack.size() == 1) {
+                IIngredientListElement<?> single = stack.getDisplayIngredients().get(0);
+                return ClickedIngredient.create(single.getIngredient(), collapsedHovered.getArea());
+            }
             return collapsedHovered.getClickedIngredient();
         }
         IngredientRenderer hovered = getHovered(mouseX, mouseY);


### PR DESCRIPTION
During the cleanup commit some functionality was dropped / broken, this fixes the following.

Fix collapsed groups to have consistent order and previews.
Fix searches to apply to collapsed groups, filtering ingredients within it.
Fix searches that result in a single ingredient, actions apply to that ingredient (view recipe / spawn / ect).
Changes collapsed groups to not be able to be bookmarked, functionality is currently not there to allow this.

If anything here added something back that breaks something I'm not aware of, let me know and I'll try and sort it out. If any of this falls in the "I didn't think that was intended behavior", and maybe an option is warranted, I will implement settings to it, I personally believe this is how it should be.