### PR TITLE
Recipe Category Header Fix

### DIFF
--- a/src/main/java/mezz/jei/gui/PageNavigation.java
+++ b/src/main/java/mezz/jei/gui/PageNavigation.java
@@ -49,13 +49,15 @@ public class PageNavigation {
 	}
 
 	public void draw(Minecraft minecraft, int mouseX, int mouseY, float partialTicks) {
-		if (this.paged.hasNext()) {
+		boolean next = this.paged.hasNext();
+		boolean previous = this.paged.hasPrevious();
+		if (next) {
 			nextButton.drawButton(minecraft, mouseX, mouseY, partialTicks);
 		}
-		if (this.paged.hasPrevious()) {
+		if (previous) {
 			backButton.drawButton(minecraft, mouseX, mouseY, partialTicks);
 		}
-		if (!hideOnSinglePage) {
+		if (!hideOnSinglePage || next || previous) {
 			minecraft.fontRenderer.drawString(pageNumDisplayString, pageNumDisplayX, pageNumDisplayY, Color.white.getRGB(), true);
 		}
 	}

--- a/src/main/java/mezz/jei/gui/recipes/RecipeGuiTabs.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeGuiTabs.java
@@ -148,7 +148,7 @@ public class RecipeGuiTabs implements IMouseHandler, IPaged {
 
 	@Override
 	public boolean nextPage() {
-		if (hasNext()) {
+		if (pageNumber + 1 < pageCount) {
 			pageNumber++;
 		} else {
 			pageNumber = 0;
@@ -159,12 +159,12 @@ public class RecipeGuiTabs implements IMouseHandler, IPaged {
 
 	@Override
 	public boolean hasNext() {
-		return pageNumber + 1 < pageCount;
+		return pageCount > 1;
 	}
 
 	@Override
 	public boolean previousPage() {
-		if (hasPrevious()) {
+		if (pageNumber > 0) {
 			pageNumber--;
 		} else {
 			pageNumber = pageCount - 1;
@@ -175,7 +175,7 @@ public class RecipeGuiTabs implements IMouseHandler, IPaged {
 
 	@Override
 	public boolean hasPrevious() {
-		return pageNumber > 0;
+		return pageCount > 1;
 	}
 
 	@Override


### PR DESCRIPTION
changes in this PR:
- fixes recipe category tabs not having the previous page button the first page nor the next page button on the last page.
- fixes recipe category tabs not having the page number displayed.

caused by a series of commits [here](https://github.com/CleanroomMC/HadEnoughItems/compare/4.29.9...4.29.12?diff=split&w#diff-f4dc9266682c1723e76eca8d931a5153756a6297ec24831505f786632bc5f601), which changed the logic from `if (!hideOnSinglePage || this.paged.hasNext() || this.paged.hasPrevious()) { page; buttons; }` - meaning all buttons and the page number would display if any of them would display - to `if (next) button; if (previous) button; if (!hideOnSinglePage) page;`.