### PR TITLE
Category UID tooltip

### DIFF
--- a/src/main/java/mezz/jei/gui/recipes/RecipeCategoryTab.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeCategoryTab.java
@@ -17,6 +17,7 @@ import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.ingredients.IngredientRegistry;
 import mezz.jei.startup.ForgeModIdHelper;
 import mezz.jei.util.LegacyUtil;
+import net.minecraft.util.text.TextFormatting;
 import org.apache.commons.lang3.mutable.MutableObject;
 
 import javax.annotation.Nullable;
@@ -98,6 +99,10 @@ public class RecipeCategoryTab extends RecipeGuiTab {
 		//noinspection ConstantConditions
 		if (title != null) {
 			tooltip.add(title);
+		}
+
+		if (Minecraft.getMinecraft().gameSettings.advancedItemTooltips) {
+			tooltip.add(TextFormatting.DARK_GRAY + category.getUid());
 		}
 
 		String modName = LegacyUtil.getModName(category);


### PR DESCRIPTION
changes in this PR:
- add a line to the tooltip for the category containing the category uid when advanced tooltips are enabled.

this is inspired by a feature from [NomiLabs](https://github.com/Nomi-CEu/Nomi-Labs/blob/main/src/main/java/com/nomiceu/nomilabs/mixin/jei/RecipeCategoryTabMixin.java), with the main difference being they have it as the final line of the tooltip and `Category ID: ${id}` instead of just the id itself. this difference is to better mimic how ItemStacks display their ResourceLocation.