### PR TITLE
Fix regression with NBT differentiated itemstacks.

### DIFF
--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -69,6 +69,16 @@ public interface IIngredientHelper<V> {
 	String getUniqueId(V ingredient);
 
 	/**
+	 * Fully unique ID that includes all variant information for use in
+	 * ingredient-list deduplication. Delegates to {@link #getUniqueId}
+	 * 
+	 * @since HEI 4.30.4
+	 */
+	default String getFullUniqueId(V ingredient) {
+		return getUniqueId(ingredient);
+	}
+
+	/**
 	 * Entirely unique ID for use in comparing, blacklisting, and looking up ingredients by count, NBT, and any other possible variation.
 	 *
 	 * @since JEI 3.11.0

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
@@ -76,6 +76,12 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 	}
 
 	@Override
+	public String getFullUniqueId(ItemStack ingredient) {
+		ErrorUtil.checkNotEmpty(ingredient);
+		return stackHelper.getUniqueIdentifierForStack(ingredient, StackHelper.UidMode.FULL);
+	}
+
+	@Override
 	public int getHash(ItemStack ingredient) {
 		Integer cachedHash = hashCache.get(ingredient);
 		if (cachedHash != null) {

--- a/src/main/java/mezz/jei/util/IngredientSet.java
+++ b/src/main/java/mezz/jei/util/IngredientSet.java
@@ -9,13 +9,24 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import net.minecraft.item.ItemStack;
 
+import mezz.jei.Internal;
 import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IIngredientType;
+import mezz.jei.startup.StackHelper;
 
 public class IngredientSet<V> extends AbstractSet<V> {
 	public static <V> IngredientSet<V> create(IIngredientType<V> ingredientType, IIngredientHelper<V> ingredientHelper) {
-		return new IngredientSet<>(ingredientHelper::getUniqueId);
+		final Function<V, String> uidGenerator;
+		if (ingredientType == VanillaTypes.ITEM) {
+			StackHelper stackHelper = Internal.getStackHelper();
+			uidGenerator = stack -> stackHelper.getUniqueIdentifierForStack((ItemStack) stack, StackHelper.UidMode.FULL);
+		} else {
+			uidGenerator = ingredientHelper::getUniqueId;
+		}
+		return new IngredientSet<>(uidGenerator);
 	}
 
 	private final Function<V, String> uidGenerator;

--- a/src/main/java/mezz/jei/util/IngredientSet.java
+++ b/src/main/java/mezz/jei/util/IngredientSet.java
@@ -9,24 +9,13 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
-import net.minecraft.item.ItemStack;
 
-import mezz.jei.Internal;
 import mezz.jei.api.ingredients.IIngredientHelper;
-import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IIngredientType;
-import mezz.jei.startup.StackHelper;
 
 public class IngredientSet<V> extends AbstractSet<V> {
 	public static <V> IngredientSet<V> create(IIngredientType<V> ingredientType, IIngredientHelper<V> ingredientHelper) {
-		final Function<V, String> uidGenerator;
-		if (ingredientType == VanillaTypes.ITEM) {
-			StackHelper stackHelper = Internal.getStackHelper();
-			uidGenerator = stack -> stackHelper.getUniqueIdentifierForStack((ItemStack) stack, StackHelper.UidMode.FULL);
-		} else {
-			uidGenerator = ingredientHelper::getUniqueId;
-		}
-		return new IngredientSet<>(uidGenerator);
+		return new IngredientSet<>(ingredientHelper::getFullUniqueId);
 	}
 
 	private final Function<V, String> uidGenerator;


### PR DESCRIPTION
7fcdfb5 cleanup commit changed this block, it causes a regression with items under the same meta space without a subtype but different NBT.

This might have other avenues of fixing, but as it stands now this is where it was introduced. 