### PR TITLE
Optimize Indexing Speed

### DIFF
--- a/src/main/java/mezz/jei/search/Node.java
+++ b/src/main/java/mezz/jei/search/Node.java
@@ -20,6 +20,7 @@ import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
 import it.unimi.dsi.fastutil.chars.Char2ObjectMaps;
 import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrays;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import mezz.jei.collect.Char2ObjectSingletonMap;
 import mezz.jei.util.Substring;
 import org.apache.commons.lang3.ArrayUtils;
@@ -44,7 +45,7 @@ public class Node<T> extends Substring {
      * The payload array used to store the data (indexes) associated with this node.
      * In this case, it is used to store all property indexes.
      */
-    private T[] data;
+    private ObjectOpenHashSet<T> data;
 
     /**
      * The set of edges starting from this node
@@ -61,7 +62,7 @@ public class Node<T> extends Substring {
 
     Node(Substring string) {
         super(string);
-        this.data = (T[]) ObjectArrays.EMPTY_ARRAY;
+        this.data = new ObjectOpenHashSet<>(0);
         this.edges = Char2ObjectMaps.emptyMap();
         this.suffix = null;
     }
@@ -71,9 +72,7 @@ public class Node<T> extends Substring {
      * of the path to this node is a substring of the one of the children nodes.
      */
     void getData(Collection<T> collection) {
-        for (int i = 0; i < data.length; i++) {
-            collection.add(data[i]);
-        }
+        collection.addAll(this.data);
         for (Node<T> e : edges.values()) {
             e.getData(collection);
         }
@@ -107,12 +106,7 @@ public class Node<T> extends Substring {
      * @return true <tt>this</tt> contains a reference to index
      */
     protected boolean contains(T index) {
-        for (T t : data) {
-            if (t == index) {
-                return true;
-            }
-        }
-        return false;
+        return data.contains(index);
     }
 
     protected void addEdge(Node<T> e) {
@@ -154,14 +148,13 @@ public class Node<T> extends Substring {
         this.suffix = suffix;
     }
 
-    // TODO: check performance
     protected void addValue(T index) {
-        this.data = ArrayUtils.add(this.data, index);
+        this.data.add(index);
     }
 
     @Override
     public String toString() {
-        return "Node: size:" + (data.length) + " Edges: " + edges;
+        return "Node: size:" + data.size() + " Edges: " + edges;
     }
 
     public IntSummaryStatistics nodeSizeStats() {
@@ -169,7 +162,7 @@ public class Node<T> extends Substring {
     }
 
     private IntStream nodeSizes() {
-        return IntStream.concat(IntStream.of(data.length), edges.values().stream().flatMapToInt(Node::nodeSizes));
+        return IntStream.concat(IntStream.of(data.size()), edges.values().stream().flatMapToInt(Node::nodeSizes));
     }
 
     public String nodeEdgeStats() {
@@ -207,7 +200,7 @@ public class Node<T> extends Substring {
 
     private void printLeaves(PrintWriter out) {
         if (edges.isEmpty()) {
-            out.println("\t" + nodeId(this) + " [label=\"" + Arrays.toString(data) + "\",shape=point,style=filled,fillcolor=lightgrey,shape=circle,width=.07,height=.07]");
+            out.println("\t" + nodeId(this) + " [label=\"" + data + "\",shape=point,style=filled,fillcolor=lightgrey,shape=circle,width=.07,height=.07]");
         } else {
             for (Node<T> edge : edges.values()) {
                 edge.printLeaves(out);
@@ -217,7 +210,7 @@ public class Node<T> extends Substring {
 
     private void printInternalNodes(Node<T> root, PrintWriter out) {
         if (this != root && !edges.isEmpty()) {
-            out.println("\t" + nodeId(this) + " [label=\"" + Arrays.toString(data) + "\",style=filled,fillcolor=lightgrey,shape=circle,width=.07,height=.07]");
+            out.println("\t" + nodeId(this) + " [label=\"" + data + "\",style=filled,fillcolor=lightgrey,shape=circle,width=.07,height=.07]");
         }
         for (Node<T> edge : edges.values()) {
             edge.printInternalNodes(root, out);


### PR DESCRIPTION
This reduces the load time for MeatBallCraft from 11 minutes, down to 5-6 minutes. Most of the time was taken up by the O(n) add-if-not-present operation in Node, so I swapped out the object array with a fastutils ObjectOpenHashSet.

I'm not sure if it needs to be ordered, but if it does I can swap to the Linked variant. I used the non-linked variant to reduce allocations, since Linked collections have to maintain a separate ordering array.