### PR TITLE
Unfocus Keyboard on Recipe GUI update

### DIFF
--- a/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -583,6 +583,9 @@ public class RecipesGui extends GuiScreen implements IRecipesGui, IShowsRecipeFo
 		final int titleY = guiTop + borderPadding;
 		titleHoverChecker = new HoverChecker(titleY, titleY + fontRenderer.FONT_HEIGHT, titleX, titleX + titleWidth, 0);
 
+		this.searchField.setText(this.logic.getSearchFilter());
+		setKeyboardFocus(this.logic.getSearchMode() != RecipeSearchMode.NONE);
+
 		int spacingY = recipeBackground.getHeight() + recipeSpacing;
 
 		recipeLayouts.clear();
@@ -655,7 +658,6 @@ public class RecipesGui extends GuiScreen implements IRecipesGui, IShowsRecipeFo
 
 	@Override
 	public void onStateChange() {
-		this.searchField.setText(this.logic.getSearchFilter());
 		updateLayout();
 	}
 


### PR DESCRIPTION
changes in this PR:
- when updating the layout, also change the focus based on the recipe search mode.

this fixes an issue wherein if you had the search focused and then clicking an ingredient on the sidebar, the search field would still block keypresses like r/u from working