### PR TITLE
Fix enable mode for filter

### DIFF
--- a/src/main/java/mezz/jei/search/TokenInfo.java
+++ b/src/main/java/mezz/jei/search/TokenInfo.java
@@ -9,7 +9,7 @@ public class TokenInfo {
             return null;
         }
         PrefixInfo prefixInfo = PrefixInfo.get(token.charAt(0));
-        if (prefixInfo != null && prefixInfo.getMode() == Config.SearchMode.REQUIRE_PREFIX) {
+        if (prefixInfo != null && (prefixInfo.getMode() == Config.SearchMode.REQUIRE_PREFIX || prefixInfo.getMode() == Config.SearchMode.ENABLED)) {
             token = token.substring(1);
             if (token.isEmpty()) {
                 return null;


### PR DESCRIPTION
Previously when in "enabled" mode for "@modname", using "@" would cause nothing to show up. 

This PR makes it so that using "@" is optional when in "enabled" mode (this is how JEI works).