### PR TITLE
Build cache early to improve GUI init hickups. Early exit for wildcard prefixes with collapsed groups.

### DIFF
--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -180,7 +180,7 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 				}
 				for (Map.Entry<String, CollapsibleGroup> entry : wildcardEntries) {
 					String prefix = entry.getKey();
-					if (uid.equals(prefix) || uid.startsWith(prefix + ":")) {
+					if (uid.equals(prefix) || (uid.length() > prefix.length() && uid.charAt(prefix.length()) == ':' && uid.startsWith(prefix))) {
 						groupMembershipCache.put(element, entry.getValue());
 						gtoc.put(entry.getValue(), element);
 					}
@@ -281,6 +281,7 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 		for (IIngredientListElement<?> element : this.elementSearch.getAllIngredients()) {
 			updateHiddenState(element);
 		}
+		buildCache();
 	}
 
 	public <V> void updateHiddenState(IIngredientListElement<V> element) {

--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -103,6 +103,7 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 		if (this.afterBlock) {
 			runnable.run();
 			invalidateCache();
+			buildCache();
 		} else {
 			if (this.delegatedActions == null) {
 				this.delegatedActions = new ArrayList<>();


### PR DESCRIPTION
I don't quite know the consequences of placing buildCache in the two locations that they are, so I'm going to draft this instead do it doesn't get (ahem..) accidentally merged.

The early exits for the prefixes I am more sure about, so at the very least let me know about the buildCache and if its bad, I'll remove them.

Fixes #204 