### PR TITLE
Optimize AnvilRecipe storage

### DIFF
--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
@@ -1,11 +1,11 @@
 package mezz.jei.plugins.vanilla;
 
-import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import mezz.jei.api.recipe.IVanillaRecipeFactory;
 import mezz.jei.plugins.vanilla.anvil.AnvilRecipeWrapper;
@@ -21,7 +21,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
 
-		return new AnvilRecipeWrapper(Collections.singletonList(leftInput), rightInputs, outputs);
+		return new AnvilRecipeWrapper(ImmutableList.of(leftInput), ImmutableList.copyOf(rightInputs), ImmutableList.copyOf(outputs));
 	}
 
 	@Override
@@ -32,7 +32,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 		Preconditions.checkArgument(leftInputs.size() == rightInputs.size(), "Both input sizes must match.");
 		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
 
-		return new AnvilRecipeWrapper(leftInputs, rightInputs, outputs);
+		return new AnvilRecipeWrapper(ImmutableList.copyOf(leftInputs), ImmutableList.copyOf(rightInputs), ImmutableList.copyOf(outputs));
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -120,7 +120,7 @@ public final class AnvilRecipeMaker {
 				.filter(enchantedBooks -> !enchantedBooks.isEmpty())
 				.map(enchantedBooks -> {
 					List<ItemStack> outputs = getEnchantedIngredients(ingredient, enchantedBooks);
-					// All lists here are immutable, except enchantedBooks which is a transforming list,
+					// All lists here are immutable, except outputs which is a transforming list,
 					// so we call the constructor directly
 					return new AnvilRecipeWrapper(ingredientSingletonList, enchantedBooks, outputs);
 				});

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -1,13 +1,19 @@
 package mezz.jei.plugins.vanilla.anvil;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemEnchantedBook;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import net.minecraftforge.oredict.OreDictionary;
 import net.minecraft.client.Minecraft;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -21,177 +27,246 @@ import net.minecraft.item.ItemStack;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import mezz.jei.api.recipe.IVanillaRecipeFactory;
 import mezz.jei.util.ErrorUtil;
 import mezz.jei.util.Log;
+import net.minecraftforge.oredict.OreDictionary;
 
 public final class AnvilRecipeMaker {
-	private static final ItemStack ENCHANTED_BOOK = new ItemStack(Items.ENCHANTED_BOOK);
-
 	private AnvilRecipeMaker() {
 	}
 
 	public static List<IRecipeWrapper> getAnvilRecipes(IVanillaRecipeFactory vanillaRecipeFactory, IIngredientRegistry ingredientRegistry) {
-		List<IRecipeWrapper> recipes = new ArrayList<>();
 		Stopwatch sw = Stopwatch.createStarted();
-		try {
-			getRepairRecipes(recipes, vanillaRecipeFactory);
-		} catch (RuntimeException e) {
-			Log.get().error("Failed to create repair recipes.", e);
-		}
-		sw.stop();
-		Log.get().debug("Registered vanilla repair recipes in {}", sw);
-		sw.reset();
-		sw.start();
-		try {
-			getBookEnchantmentRecipes(recipes, vanillaRecipeFactory, ingredientRegistry);
-		} catch (RuntimeException e) {
-			Log.get().error("Failed to create enchantment recipes.", e);
-		}
-		sw.stop();
-		Log.get().debug("Registered enchantment recipes in {}", sw);
-		return recipes;
+		return Stream.concat(
+						wrapStream("vanilla repair", () -> getRepairRecipes(vanillaRecipeFactory), sw),
+						wrapStream("enchantment", () -> getBookEnchantmentRecipes(ingredientRegistry), sw))
+				.collect(Collectors.toList());
 	}
 
-	private static void getBookEnchantmentRecipes(List<IRecipeWrapper> recipes, IVanillaRecipeFactory vanillaRecipeFactory, IIngredientRegistry ingredientRegistry) {
+	private static <T> Stream<T> wrapStream(String name, Supplier<Stream<T>> supplier, Stopwatch stopwatch) {
+		stopwatch.reset();
+		stopwatch.start();
+		try {
+			List<T> data = supplier.get().collect(Collectors.toList());
+			Log.get().debug("Registered {} recipes in {}", name, stopwatch);
+			return data.stream();
+		} catch (RuntimeException e) {
+			Log.get().error("Failed to create {} recipes.", name, e);
+			return Stream.empty();
+		} finally {
+			stopwatch.stop();
+		}
+	}
+
+	/* Enchantment recipes */
+
+	private static final class EnchantmentData {
+		private final Enchantment enchantment;
+		// Books per enchantment level
+		private final List<ItemStack> enchantedBooks;
+
+		EnchantmentData(Enchantment enchantment) {
+			this.enchantment = enchantment;
+			this.enchantedBooks = enumerateBooks(enchantment);
+		}
+
+		@SuppressWarnings("UnstableApiUsage")
+		public List<ItemStack> getEnchantedBooks(ItemStack ingredient) {
+			Item item = ingredient.getItem();
+			List<ItemStack> list = enchantedBooks.stream()
+					.filter(enchantedBook -> item.isBookEnchantable(ingredient, enchantedBook))
+					.collect(ImmutableList.toImmutableList());
+			// avoid using copy of list if it contains the exact same items
+			return list.size() == enchantedBooks.size() ? enchantedBooks : list;
+		}
+
+		private boolean canEnchant(ItemStack ingredient) {
+			try {
+				return enchantment.canApply(ingredient);
+			} catch (RuntimeException e) {
+				String stackInfo = ErrorUtil.getItemStackInfo(ingredient);
+				Log.get().error("Failed to check if ingredient can be enchanted: {}", stackInfo, e);
+				return false;
+			}
+		}
+
+		@SuppressWarnings("UnstableApiUsage")
+		private static List<ItemStack> enumerateBooks(Enchantment enchantment) {
+			return IntStream.rangeClosed(enchantment.getMinLevel(), enchantment.getMaxLevel())
+					.mapToObj(level -> ItemEnchantedBook.getEnchantedItemStack(new net.minecraft.enchantment.EnchantmentData(enchantment, level)))
+					.collect(ImmutableList.toImmutableList());
+		}
+	}
+
+	private static Stream<IRecipeWrapper> getBookEnchantmentRecipes(IIngredientRegistry ingredientRegistry) {
+		List<EnchantmentData> enchantmentDatas = ForgeRegistries.ENCHANTMENTS.getValuesCollection().stream()
+				.map(EnchantmentData::new)
+				.collect(Collectors.toList());
 		Collection<ItemStack> ingredients = ingredientRegistry.getAllIngredients(VanillaTypes.ITEM);
-		Collection<Enchantment> enchantments = ForgeRegistries.ENCHANTMENTS.getValuesCollection();
-		for (ItemStack ingredient : ingredients) {
-			if (ingredient.isItemEnchantable()) {
-				for (Enchantment enchantment : enchantments) {
-					if (enchantment.canApply(ingredient)) {
-						try {
-							getBookEnchantmentRecipes(recipes, vanillaRecipeFactory, enchantment, ingredient);
-						} catch (RuntimeException e) {
-							String ingredientInfo = ErrorUtil.getIngredientInfo(ingredient);
-							Log.get().error("Failed to register book enchantment recipes for ingredient: {}", ingredientInfo, e);
-						}
-					}
-				}
-			}
+		return ingredients.stream()
+				.filter(ItemStack::isItemEnchantable)
+				.flatMap(ingredient -> getBookEnchantmentRecipes(enchantmentDatas, ingredient));
+	}
+
+	private static Stream<IRecipeWrapper> getBookEnchantmentRecipes(List<EnchantmentData> enchantmentDatas, ItemStack ingredient) {
+		List<ItemStack> ingredientSingletonList = ImmutableList.of(ingredient);
+		return enchantmentDatas.stream()
+				.filter(data -> data.canEnchant(ingredient))
+				.map(data -> data.getEnchantedBooks(ingredient))
+				.filter(enchantedBooks -> !enchantedBooks.isEmpty())
+				.map(enchantedBooks -> {
+					List<ItemStack> outputs = getEnchantedIngredients(ingredient, enchantedBooks);
+					// All lists here are immutable, except enchantedBooks which is a transforming list,
+					// so we call the constructor directly
+					return new AnvilRecipeWrapper(ingredientSingletonList, enchantedBooks, outputs);
+				});
+	}
+
+	private static List<ItemStack> getEnchantedIngredients(ItemStack ingredient, List<ItemStack> enchantedBooks) {
+		return Lists.transform(enchantedBooks, enchantedBook -> getEnchantedIngredient(ingredient, enchantedBook));
+	}
+
+	private static ItemStack getEnchantedIngredient(ItemStack ingredient, ItemStack enchantedBook) {
+		ItemStack enchantedIngredient = ingredient.copy();
+		Map<Enchantment, Integer> enchantments = EnchantmentHelper.getEnchantments(enchantedBook);
+		EnchantmentHelper.setEnchantments(enchantments, enchantedIngredient);
+		return enchantedIngredient;
+	}
+
+	/* Repair recipes */
+
+	private static class RepairData {
+		private final ItemStack repairIngredient;
+		private final List<ItemStack> repairables;
+
+		public RepairData(ItemStack repairIngredient, ItemStack... repairables) {
+			this.repairIngredient = repairIngredient;
+			this.repairables = Collections.unmodifiableList(Arrays.asList(repairables));
+		}
+
+		public ItemStack getRepairStack() {
+			return repairIngredient;
+		}
+
+		public List<ItemStack> getRepairables() {
+			return repairables;
 		}
 	}
 
-	private static void getBookEnchantmentRecipes(List<IRecipeWrapper> recipes, IVanillaRecipeFactory vanillaRecipeFactory, Enchantment enchantment, ItemStack ingredient) {
-		Item item = ingredient.getItem();
-		List<ItemStack> perLevelBooks = Lists.newArrayList();
-		List<ItemStack> perLevelOutputs = Lists.newArrayList();
-		for (int level = 1; level <= enchantment.getMaxLevel(); level++) {
-			Map<Enchantment, Integer> enchMap = Collections.singletonMap(enchantment, level);
-
-			ItemStack bookEnchant = ENCHANTED_BOOK.copy();
-			EnchantmentHelper.setEnchantments(enchMap, bookEnchant);
-			if (item.isBookEnchantable(ingredient, bookEnchant)) {
-				perLevelBooks.add(bookEnchant);
-
-				ItemStack withEnchant = ingredient.copy();
-				EnchantmentHelper.setEnchantments(enchMap, withEnchant);
-				perLevelOutputs.add(withEnchant);
-			}
-		}
-		if (!perLevelBooks.isEmpty() && !perLevelOutputs.isEmpty()) {
-			IRecipeWrapper anvilRecipe = vanillaRecipeFactory.createAnvilRecipe(ingredient, perLevelBooks, perLevelOutputs);
-			recipes.add(anvilRecipe);
-		}
+	private static Stream<RepairData> getRepairData() {
+		return Stream.of(
+				new RepairData(Item.ToolMaterial.WOOD.getRepairItemStack(),
+						new ItemStack(Items.WOODEN_SWORD),
+						new ItemStack(Items.WOODEN_PICKAXE),
+						new ItemStack(Items.WOODEN_AXE),
+						new ItemStack(Items.WOODEN_SHOVEL),
+						new ItemStack(Items.WOODEN_HOE)
+				),
+				new RepairData(new ItemStack(Blocks.PLANKS, 1, OreDictionary.WILDCARD_VALUE),
+						new ItemStack(Items.SHIELD)
+				),
+				new RepairData(Item.ToolMaterial.STONE.getRepairItemStack(),
+						new ItemStack(Items.STONE_SWORD),
+						new ItemStack(Items.STONE_PICKAXE),
+						new ItemStack(Items.STONE_AXE),
+						new ItemStack(Items.STONE_SHOVEL),
+						new ItemStack(Items.STONE_HOE)
+				),
+				new RepairData(ItemArmor.ArmorMaterial.LEATHER.getRepairItemStack(),
+						new ItemStack(Items.LEATHER_HELMET),
+						new ItemStack(Items.LEATHER_CHESTPLATE),
+						new ItemStack(Items.LEATHER_LEGGINGS),
+						new ItemStack(Items.LEATHER_BOOTS)
+				),
+				new RepairData(new ItemStack(Items.LEATHER),
+						new ItemStack(Items.ELYTRA)
+				),
+				new RepairData(Item.ToolMaterial.IRON.getRepairItemStack(),
+						new ItemStack(Items.IRON_SWORD),
+						new ItemStack(Items.IRON_PICKAXE),
+						new ItemStack(Items.IRON_AXE),
+						new ItemStack(Items.IRON_SHOVEL),
+						new ItemStack(Items.IRON_HOE)
+				),
+				new RepairData(ItemArmor.ArmorMaterial.IRON.getRepairItemStack(),
+						new ItemStack(Items.IRON_HELMET),
+						new ItemStack(Items.IRON_CHESTPLATE),
+						new ItemStack(Items.IRON_LEGGINGS),
+						new ItemStack(Items.IRON_BOOTS)
+				),
+				new RepairData(ItemArmor.ArmorMaterial.CHAIN.getRepairItemStack(),
+						new ItemStack(Items.CHAINMAIL_HELMET),
+						new ItemStack(Items.CHAINMAIL_CHESTPLATE),
+						new ItemStack(Items.CHAINMAIL_LEGGINGS),
+						new ItemStack(Items.CHAINMAIL_BOOTS)
+				),
+				new RepairData(Item.ToolMaterial.GOLD.getRepairItemStack(),
+						new ItemStack(Items.GOLDEN_SWORD),
+						new ItemStack(Items.GOLDEN_PICKAXE),
+						new ItemStack(Items.GOLDEN_AXE),
+						new ItemStack(Items.GOLDEN_SHOVEL),
+						new ItemStack(Items.GOLDEN_HOE)
+				),
+				new RepairData(ItemArmor.ArmorMaterial.GOLD.getRepairItemStack(),
+						new ItemStack(Items.GOLDEN_HELMET),
+						new ItemStack(Items.GOLDEN_CHESTPLATE),
+						new ItemStack(Items.GOLDEN_LEGGINGS),
+						new ItemStack(Items.GOLDEN_BOOTS)
+				),
+				new RepairData(Item.ToolMaterial.DIAMOND.getRepairItemStack(),
+						new ItemStack(Items.DIAMOND_SWORD),
+						new ItemStack(Items.DIAMOND_PICKAXE),
+						new ItemStack(Items.DIAMOND_AXE),
+						new ItemStack(Items.DIAMOND_SHOVEL),
+						new ItemStack(Items.DIAMOND_HOE)
+				),
+				new RepairData(ItemArmor.ArmorMaterial.DIAMOND.getRepairItemStack(),
+						new ItemStack(Items.DIAMOND_HELMET),
+						new ItemStack(Items.DIAMOND_CHESTPLATE),
+						new ItemStack(Items.DIAMOND_LEGGINGS),
+						new ItemStack(Items.DIAMOND_BOOTS)
+				)
+		);
 	}
 
-	private static void getRepairRecipes(List<IRecipeWrapper> recipes, IVanillaRecipeFactory vanillaRecipeFactory) {
-		Map<ItemStack, List<ItemStack>> items = Maps.newHashMap();
+	private static Stream<IRecipeWrapper> getRepairRecipes(IVanillaRecipeFactory vanillaRecipeFactory) {
+		return getRepairData().flatMap(repairData -> getRepairRecipes(repairData, vanillaRecipeFactory));
+	}
 
-		ItemStack repairWood = new ItemStack(Blocks.PLANKS, 1, OreDictionary.WILDCARD_VALUE);
-		items.put(repairWood, Lists.newArrayList(
-			new ItemStack(Items.WOODEN_SWORD),
-			new ItemStack(Items.WOODEN_PICKAXE),
-			new ItemStack(Items.WOODEN_AXE),
-			new ItemStack(Items.WOODEN_SHOVEL),
-			new ItemStack(Items.WOODEN_HOE),
-			new ItemStack(Items.SHIELD)
-		));
+	private static Stream<IRecipeWrapper> getRepairRecipes(RepairData repairData, IVanillaRecipeFactory vanillaRecipeFactory) {
+		List<ItemStack> repairStackInput = ImmutableList.of(repairData.getRepairStack());
+		List<ItemStack> repairables = repairData.getRepairables();
+		Stream.Builder<IRecipeWrapper> recipes = Stream.builder();
 
-		ItemStack repairStone = new ItemStack(Blocks.COBBLESTONE);
-		items.put(repairStone, Lists.newArrayList(
-			new ItemStack(Items.STONE_SWORD),
-			new ItemStack(Items.STONE_PICKAXE),
-			new ItemStack(Items.STONE_AXE),
-			new ItemStack(Items.STONE_SHOVEL),
-			new ItemStack(Items.STONE_HOE)
-		));
+		for (ItemStack repairable : repairables) {
+			ItemStack damagedThreeQuarters = repairable.copy();
+			damagedThreeQuarters.setItemDamage(damagedThreeQuarters.getMaxDamage() * 3 / 4);
+			ItemStack damagedHalf = repairable.copy();
+			damagedHalf.setItemDamage(damagedHalf.getMaxDamage() / 2);
 
-		ItemStack repairLeather = new ItemStack(Items.LEATHER);
-		items.put(repairLeather, Lists.newArrayList(
-			new ItemStack(Items.LEATHER_HELMET),
-			new ItemStack(Items.LEATHER_CHESTPLATE),
-			new ItemStack(Items.LEATHER_LEGGINGS),
-			new ItemStack(Items.LEATHER_BOOTS),
-			new ItemStack(Items.ELYTRA)
-		));
+			List<ItemStack> damagedThreeQuartersSingletonList = ImmutableList.of(damagedThreeQuarters);
+			IRecipeWrapper repairWithSame = vanillaRecipeFactory.createAnvilRecipe(
+					damagedThreeQuartersSingletonList,
+					damagedThreeQuartersSingletonList,
+					ImmutableList.of(damagedHalf)
+			);
+			recipes.add(repairWithSame);
 
-		ItemStack repairIron = new ItemStack(Items.IRON_INGOT);
-		items.put(repairIron, Lists.newArrayList(
-			new ItemStack(Items.IRON_SWORD),
-			new ItemStack(Items.IRON_PICKAXE),
-			new ItemStack(Items.IRON_AXE),
-			new ItemStack(Items.IRON_SHOVEL),
-			new ItemStack(Items.IRON_HOE),
-			new ItemStack(Items.IRON_HELMET),
-			new ItemStack(Items.IRON_CHESTPLATE),
-			new ItemStack(Items.IRON_LEGGINGS),
-			new ItemStack(Items.IRON_BOOTS),
-			new ItemStack(Items.CHAINMAIL_HELMET),
-			new ItemStack(Items.CHAINMAIL_CHESTPLATE),
-			new ItemStack(Items.CHAINMAIL_LEGGINGS),
-			new ItemStack(Items.CHAINMAIL_BOOTS)
-		));
-
-		ItemStack repairGold = new ItemStack(Items.GOLD_INGOT);
-		items.put(repairGold, Lists.newArrayList(
-			new ItemStack(Items.GOLDEN_SWORD),
-			new ItemStack(Items.GOLDEN_PICKAXE),
-			new ItemStack(Items.GOLDEN_AXE),
-			new ItemStack(Items.GOLDEN_SHOVEL),
-			new ItemStack(Items.GOLDEN_HOE),
-			new ItemStack(Items.GOLDEN_HELMET),
-			new ItemStack(Items.GOLDEN_CHESTPLATE),
-			new ItemStack(Items.GOLDEN_LEGGINGS),
-			new ItemStack(Items.GOLDEN_BOOTS)
-		));
-
-		ItemStack repairDiamond = new ItemStack(Items.DIAMOND);
-		items.put(repairDiamond, Lists.newArrayList(
-			new ItemStack(Items.DIAMOND_SWORD),
-			new ItemStack(Items.DIAMOND_PICKAXE),
-			new ItemStack(Items.DIAMOND_AXE),
-			new ItemStack(Items.DIAMOND_SHOVEL),
-			new ItemStack(Items.DIAMOND_HOE),
-			new ItemStack(Items.DIAMOND_HELMET),
-			new ItemStack(Items.DIAMOND_CHESTPLATE),
-			new ItemStack(Items.DIAMOND_LEGGINGS),
-			new ItemStack(Items.DIAMOND_BOOTS)
-		));
-
-		for (Map.Entry<ItemStack, List<ItemStack>> entry : items.entrySet()) {
-
-			ItemStack repairMaterial = entry.getKey();
-
-			for (ItemStack ingredient : entry.getValue()) {
-
-				ItemStack damaged1 = ingredient.copy();
-				damaged1.setItemDamage(damaged1.getMaxDamage());
-				ItemStack damaged2 = ingredient.copy();
-				damaged2.setItemDamage(damaged2.getMaxDamage() * 3 / 4);
-				ItemStack damaged3 = ingredient.copy();
-				damaged3.setItemDamage(damaged3.getMaxDamage() * 2 / 4);
-
-				IRecipeWrapper repairWithMaterial = vanillaRecipeFactory.createAnvilRecipe(damaged1, Collections.singletonList(repairMaterial), Collections.singletonList(damaged2));
-				IRecipeWrapper repairWithSame = vanillaRecipeFactory.createAnvilRecipe(damaged2, Collections.singletonList(damaged2), Collections.singletonList(damaged3));
-				recipes.add(repairWithMaterial);
-				recipes.add(repairWithSame);
-			}
+			ItemStack damagedFully = repairable.copy();
+			damagedFully.setItemDamage(damagedFully.getMaxDamage());
+			IRecipeWrapper repairWithMaterial = vanillaRecipeFactory.createAnvilRecipe(
+					ImmutableList.of(damagedFully),
+					repairStackInput,
+					damagedThreeQuartersSingletonList
+			);
+			recipes.add(repairWithMaterial);
 		}
+
+		return recipes.build();
 	}
 
 	public static int findLevelsCost(ItemStack leftStack, ItemStack rightStack) {

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -16,12 +16,14 @@ import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 
 public class AnvilRecipeWrapper implements IRecipeWrapper {
-	private final List<List<ItemStack>> inputs;
-	private final List<List<ItemStack>> output;
+	private final List<ItemStack> leftInputs;
+	private final List<ItemStack> rightInputs;
+	private final List<ItemStack> output;
 
-	public AnvilRecipeWrapper(List<ItemStack> leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
-		this.inputs = ImmutableList.of(leftInput, rightInputs);
-		this.output = ImmutableList.of(outputs);
+	public AnvilRecipeWrapper(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs) {
+		this.leftInputs = leftInputs;
+		this.rightInputs = rightInputs;
+		this.output = outputs;
 	}
 
 	@Override
@@ -86,7 +88,7 @@ public class AnvilRecipeWrapper implements IRecipeWrapper {
 
 	@Override
 	public void getIngredients(IIngredients ingredients) {
-		ingredients.setInputLists(VanillaTypes.ITEM, inputs);
-		ingredients.setOutputLists(VanillaTypes.ITEM, output);
+		ingredients.setInputLists(VanillaTypes.ITEM, ImmutableList.of(leftInputs, rightInputs));
+		ingredients.setOutputLists(VanillaTypes.ITEM, ImmutableList.of(output));
 	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -1,6 +1,5 @@
 package mezz.jei.plugins.vanilla.anvil;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -22,7 +21,7 @@ public class AnvilRecipeWrapper implements IRecipeWrapper {
 
 	public AnvilRecipeWrapper(List<ItemStack> leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
 		this.inputs = ImmutableList.of(leftInput, rightInputs);
-		this.output = Collections.singletonList(outputs);
+		this.output = ImmutableList.of(outputs);
 	}
 
 	@Override
@@ -44,8 +43,8 @@ public class AnvilRecipeWrapper implements IRecipeWrapper {
 		ItemStack lastRightStack = data.getLastRightStack();
 		int lastCost = data.getLastCost();
 		if (lastLeftStack == null || lastRightStack == null
-			|| !ItemStack.areItemStacksEqual(lastLeftStack, newLeftStack)
-			|| !ItemStack.areItemStacksEqual(lastRightStack, newRightStack)) {
+				|| !ItemStack.areItemStacksEqual(lastLeftStack, newLeftStack)
+				|| !ItemStack.areItemStacksEqual(lastRightStack, newRightStack)) {
 			lastCost = AnvilRecipeMaker.findLevelsCost(newLeftStack, newRightStack);
 			data.setLast(newLeftStack, newRightStack, lastCost);
 		}
@@ -57,8 +56,8 @@ public class AnvilRecipeWrapper implements IRecipeWrapper {
 			int mainColor = 0xFF80FF20;
 			EntityPlayerSP player = minecraft.player;
 			if (player != null &&
-				(lastCost >= 40 || lastCost > player.experienceLevel) &&
-				!player.capabilities.isCreativeMode) {
+					(lastCost >= 40 || lastCost > player.experienceLevel) &&
+					!player.capabilities.isCreativeMode) {
 				// Show red if the player doesn't have enough levels
 				mainColor = 0xFFFF6060;
 			}

--- a/src/main/java/mezz/jei/startup/ModRegistry.java
+++ b/src/main/java/mezz/jei/startup/ModRegistry.java
@@ -295,7 +295,7 @@ public class ModRegistry implements IModRegistry, IRecipeCategoryRegistration {
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
 
-		AnvilRecipeWrapper anvilRecipeWrapper = new AnvilRecipeWrapper(Collections.singletonList(leftInput), rightInputs, outputs);
+		AnvilRecipeWrapper anvilRecipeWrapper = new AnvilRecipeWrapper(ImmutableList.of(leftInput), rightInputs, outputs);
 		addRecipes(Collections.singletonList(anvilRecipeWrapper), VanillaRecipeCategoryUid.ANVIL);
 	}
 


### PR DESCRIPTION
This PR backports mezz/JustEnoughItems#3733, see it for more technical details.
Testing on a large modpack (MeatballCraft):
- Memory usage by `AnvilRecipeWrapper`s: `36.1 MB -> 8.4 MB`.
- Vanilla repair recipe creation time (during game load): `0.81ms -> 1.4ms`.
- Enchantment recipe creation time (during game load): `165.9ms -> 86.94ms`.