### PR TITLE
include bookmarked recipes when populating recipe chain

### DIFF
--- a/src/main/java/mezz/jei/autocrafting/RecipeBookmarkItem.java
+++ b/src/main/java/mezz/jei/autocrafting/RecipeBookmarkItem.java
@@ -15,6 +15,7 @@ import mezz.jei.ingredients.Ingredients;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -70,8 +71,28 @@ public class RecipeBookmarkItem<I> extends BookmarkItem<I> {
         }
         for (I alias : aliases) {
             IRecipeWrapper favorite = FavoriteRecipes.getFavorite(alias);
+            IRecipeCategory<?> favoriteCategory = null;
+            if (favorite == null) {
+                // Find recipe from other bookmarked recipes
+                RecipeBookmarkItem<?> found = (RecipeBookmarkItem<?>) Internal.getBookmarkList()
+                    .getBookmarkGroupsInternal()
+                    .stream()
+                    .map(BookmarkGroup::getItemsInternal)
+                    .flatMap(Collection::stream)
+                    .filter(item -> item instanceof RecipeBookmarkItem
+                                    && item != this
+                                    && ((RecipeBookmarkItem<?>) item).recipe != null
+                                    && IngredientUtil.aliasesContains(((RecipeBookmarkItem<?>) item).aliases, alias))
+                    .findFirst()
+                    .orElse(null);
+                if (found != null) {
+                    favorite = found.recipe;
+                    favoriteCategory = found.category;
+                }
+            } else {
+                favoriteCategory = FavoriteRecipes.getFavoriteCategory(alias);
+            }
             if (favorite != null) {
-                IRecipeCategory<?> favoriteCategory = FavoriteRecipes.getFavoriteCategory(alias);
                 this.ingredient = alias;
                 populateWith(favorite, favoriteCategory);
                 return;

--- a/src/main/java/mezz/jei/bookmarks/BookmarkList.java
+++ b/src/main/java/mezz/jei/bookmarks/BookmarkList.java
@@ -353,4 +353,8 @@ public class BookmarkList implements IIngredientGridSource {
         notifyListenersOfChange();
         saveBookmarks();
     }
+
+    public List<BookmarkGroup> getBookmarkGroupsInternal() {
+        return list;
+    }
 }


### PR DESCRIPTION
In additional to favourite-d recipes, this PR made bookmarked recipes also be searched when populating recipe chain.

https://github.com/user-attachments/assets/455f2ace-2d97-4b93-93e9-177409db93df

