### PR TITLE
Avoid consuming scroll event if mouse is in exclusion area

### DIFF
--- a/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
@@ -220,6 +220,9 @@ public class IngredientListOverlay implements IIngredientListOverlay, IMouseHand
 
 	@Override
 	public boolean isMouseOver(int mouseX, int mouseY) {
+		if (guiScreenHelper.isInGuiExclusionArea(mouseX, mouseY)) {
+			return false;
+		}
 		if (isListDisplayed()) {
 			if (Config.isCenterSearchBarEnabled() && searchField.isMouseOver(mouseX, mouseY)) {
 				return true;

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/LeftAreaDispatcher.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/LeftAreaDispatcher.java
@@ -123,8 +123,12 @@ public class LeftAreaDispatcher implements IShowsRecipeFocuses, IGhostIngredient
 		return false;
 	}
 
+	public boolean isMouseOver(int mouseX, int mouseY) {
+		return canShow && hasContent() && !guiScreenHelper.isInGuiExclusionArea(mouseX, mouseY);
+	}
+
 	public boolean handleMouseScrolled(int mouseX, int mouseY, int dWheel) {
-		if (canShow && hasContent()) {
+		if (isMouseOver(mouseX, mouseY)) {
 			if (displayArea.contains(mouseX, mouseY)) {
 				return contents.get(current).handleMouseScrolled(mouseX, mouseY, dWheel);
 			} else if (naviArea.contains(mouseX, mouseY)) {
@@ -140,7 +144,7 @@ public class LeftAreaDispatcher implements IShowsRecipeFocuses, IGhostIngredient
 	}
 
 	public boolean handleMouseClicked(int mouseX, int mouseY, int mouseButton) {
-		if (canShow && hasContent()) {
+		if (isMouseOver(mouseX, mouseY)) {
 			if (displayArea.contains(mouseX, mouseY)) {
 				return contents.get(current).handleMouseClicked(mouseX, mouseY, mouseButton);
 			} else if (naviArea.contains(mouseX, mouseY)) {
@@ -151,7 +155,7 @@ public class LeftAreaDispatcher implements IShowsRecipeFocuses, IGhostIngredient
 	}
 
 	public boolean handleMouseReleased(int mouseX, int mouseY, int mouseButton) {
-		if (!(canShow || hasContent())) {
+		if (!isMouseOver(mouseX, mouseY)) {
 			return false;
 		}	
 

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -157,7 +157,15 @@ public class InputHandler {
 	}
 
 	private boolean handleMouseScroll(int dWheel, int mouseX, int mouseY) {
-		return ingredientListOverlay.handleMouseScrolled(mouseX, mouseY, dWheel) || leftAreaDispatcher.handleMouseScrolled(mouseX, mouseY, dWheel);
+        if (ingredientListOverlay.isMouseOver(mouseX, mouseY) && ingredientListOverlay.handleMouseScrolled(mouseX, mouseY, dWheel)) {
+            return true;
+        }
+
+        if (leftAreaDispatcher.isMouseOver(mouseX, mouseY) && leftAreaDispatcher.handleMouseScrolled(mouseX, mouseY, dWheel)) {
+            return true;
+        }
+
+        return false;
 	}
 
 	private boolean handleMouseClick(GuiScreen guiScreen, int mouseButton, int mouseX, int mouseY) {


### PR DESCRIPTION
This PR added an additional exclusion area check to avoid consuming scroll event, if the mouse is in exclusion area. Other exclusion area check in `IMouseHandler.isMouseOver(int,int)` is removed, to 1. keep implementations consistent, and 2. avoid performing the same check multiple times


Should be able to fix some mods having their scrolling handler not working, as long as they declared correct exclusion areas.