### PR TITLE
Improve navigation layout around GUI exclusion areas

### DIFF
--- a/src/main/java/mezz/jei/gui/navigation/NavigationLayout.java
+++ b/src/main/java/mezz/jei/gui/navigation/NavigationLayout.java
@@ -1,0 +1,179 @@
+package mezz.jei.gui.navigation;
+
+import mezz.jei.util.ErrorUtil;
+
+import javax.annotation.Nullable;
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Calculates a page-navigation strip that stays attached to one horizontal edge while avoiding GUI exclusion
+ * areas. Navigation is shortened at its current height before it is moved down, while content keeps the full
+ * available width.
+ */
+public final class NavigationLayout {
+
+    private NavigationLayout() {
+    }
+
+    /**
+     * Finds the first usable navigation strip within an available area.
+     *
+     * @param availableArea the full area shared by navigation and content
+     * @param exclusionAreas caller-owned GUI areas that navigation must not overlap
+     * @param alignment the horizontal edge that navigation must stay attached to
+     * @param navigationHeight the fixed navigation height
+     * @param minimumNavigationWidth the minimum usable navigation width
+     * @param maximumNavigationWidth the preferred maximum navigation width
+     * @return the navigation and remaining content areas, or empty when navigation cannot fit
+     * @throws NullPointerException if an object argument or exclusion element is null
+     * @throws IllegalArgumentException if the available area or a requested dimension is non-positive
+     */
+    @Nullable
+    public static Result calculate(Rectangle availableArea, Collection<Rectangle> exclusionAreas,
+                                   Alignment alignment, int navigationHeight,
+                                   int minimumNavigationWidth, int maximumNavigationWidth) {
+        ErrorUtil.checkNotNull(availableArea, "availableArea");
+        ErrorUtil.checkNotNull(exclusionAreas, "exclusionAreas");
+        ErrorUtil.checkNotNull(alignment, "alignment");
+        validateDimensions(availableArea, navigationHeight, minimumNavigationWidth, maximumNavigationWidth);
+
+        List<Rectangle> exclusions = copyClippedExclusions(availableArea, exclusionAreas);
+        int widthLimit = Math.min(availableArea.width, maximumNavigationWidth);
+        if (widthLimit < minimumNavigationWidth || availableArea.height < navigationHeight) {
+            return null;
+        }
+
+        int availableRight = availableArea.x + availableArea.width;
+        int availableBottom = availableArea.y + availableArea.height;
+        int candidateY = availableArea.y;
+
+        // Each pass either returns a usable anchored interval or advances to the earliest mandatory blocker bottom.
+        while (candidateY + navigationHeight <= availableBottom) {
+            int stripLeft = alignment == Alignment.LEFT ? availableArea.x : availableRight - widthLimit;
+            int stripRight = alignment == Alignment.LEFT ? availableArea.x + widthLimit : availableRight;
+            int mandatoryLeft = alignment == Alignment.LEFT ?
+                availableArea.x :
+                availableRight - minimumNavigationWidth;
+            int mandatoryRight = alignment == Alignment.LEFT ?
+                availableArea.x + minimumNavigationWidth :
+                availableRight;
+            int anchoredBoundary = alignment == Alignment.LEFT ? stripRight : stripLeft;
+            int earliestBlockingBottom = Integer.MAX_VALUE;
+            int candidateBottom = candidateY + navigationHeight;
+
+            for (Rectangle exclusion : exclusions) {
+                int exclusionRight = exclusion.x + exclusion.width;
+                int exclusionBottom = exclusion.y + exclusion.height;
+                if (exclusion.y >= candidateBottom || exclusionBottom <= candidateY) {
+                    continue;
+                }
+
+                if (exclusion.x < stripRight && exclusionRight > stripLeft) {
+                    anchoredBoundary = alignment == Alignment.LEFT ?
+                        Math.min(anchoredBoundary, Math.max(stripLeft, exclusion.x)) :
+                        Math.max(anchoredBoundary, Math.min(stripRight, exclusionRight));
+                }
+                if (exclusion.x < mandatoryRight && exclusionRight > mandatoryLeft) {
+                    earliestBlockingBottom = Math.min(earliestBlockingBottom, exclusionBottom);
+                }
+            }
+
+            int navigationWidth = alignment == Alignment.LEFT ?
+                anchoredBoundary - stripLeft :
+                stripRight - anchoredBoundary;
+            if (navigationWidth >= minimumNavigationWidth) {
+                int navigationX = alignment == Alignment.LEFT ? availableArea.x : availableRight - navigationWidth;
+                Rectangle navigationArea = new Rectangle(
+                    navigationX,
+                    candidateY,
+                    navigationWidth,
+                    navigationHeight
+                );
+                Rectangle contentArea = new Rectangle(
+                    availableArea.x,
+                    candidateBottom,
+                    availableArea.width,
+                    availableBottom - candidateBottom
+                );
+                return new Result(navigationArea, contentArea);
+            }
+
+            if (earliestBlockingBottom == Integer.MAX_VALUE) {
+                throw new IllegalStateException("A shortened navigation strip has no mandatory-width blocker");
+            }
+            candidateY = earliestBlockingBottom;
+        }
+        return null;
+    }
+
+    private static void validateDimensions(
+        Rectangle availableArea,
+        int navigationHeight,
+        int minimumNavigationWidth,
+        int maximumNavigationWidth
+    ) {
+        if (availableArea.width <= 0 || availableArea.height <= 0) {
+            throw new IllegalArgumentException("availableArea must have positive width and height");
+        }
+        if (navigationHeight <= 0 || minimumNavigationWidth <= 0 || maximumNavigationWidth <= 0) {
+            throw new IllegalArgumentException("navigation dimensions must be positive");
+        }
+    }
+
+    private static List<Rectangle> copyClippedExclusions(Rectangle availableArea,
+                                                         Collection<Rectangle> exclusionAreas) {
+        List<Rectangle> clippedExclusions = new ArrayList<>(exclusionAreas.size());
+        for (Rectangle exclusionArea : exclusionAreas) {
+            Objects.requireNonNull(exclusionArea, "exclusionAreas contains null");
+            if (exclusionArea.width <= 0 || exclusionArea.height <= 0) {
+                continue;
+            }
+            Rectangle clipped = availableArea.intersection(exclusionArea);
+            if (clipped.width > 0 && clipped.height > 0) {
+                clippedExclusions.add(clipped);
+            }
+        }
+        return clippedExclusions;
+    }
+
+    /** Selects the horizontal edge that navigation stays attached to. */
+    public enum Alignment {
+        /** Attach navigation to the left edge. */
+        LEFT,
+        /** Attach navigation to the right edge. */
+        RIGHT
+    }
+
+    /**
+     * Immutable navigation calculation result. Returned rectangles are defensive copies because
+     * {@link Rectangle} is mutable.
+     */
+    public static final class Result {
+
+        private final Rectangle navigationArea;
+        private final Rectangle contentArea;
+
+        private Result(Rectangle navigationArea, Rectangle contentArea) {
+            this.navigationArea = new Rectangle(navigationArea);
+            this.contentArea = new Rectangle(contentArea);
+        }
+
+        /**
+         * @return a defensive copy of the collision-free navigation area
+         */
+        public Rectangle getNavigationArea() {
+            return new Rectangle(navigationArea);
+        }
+
+        /**
+         * @return a defensive copy of the full-width content area below navigation
+         */
+        public Rectangle getContentArea() {
+            return new Rectangle(contentArea);
+        }
+    }
+}

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
@@ -29,7 +29,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -59,9 +59,26 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 		return this.guiIngredientSlots.getMaxSize();
 	}
 
-	public boolean updateBounds(Rectangle availableArea, int minWidth, Collection<Rectangle> exclusionAreas) {
+    public void clearLayout() {
+        this.area = new Rectangle();
+        this.guiIngredientSlots.clear();
+    }
+
+    boolean updateBoundsForNavigation(Rectangle availableArea, int minWidth, Collection<Rectangle> exclusionAreas) {
+        return updateBounds(availableArea, minWidth, exclusionAreas, false);
+    }
+
+    public boolean updateBounds(Rectangle availableArea, int minWidth, Collection<Rectangle> exclusionAreas) {
+        return updateBounds(availableArea, minWidth, exclusionAreas, true);
+    }
+
+    private boolean updateBounds(Rectangle availableArea, int minWidth, Collection<Rectangle> exclusionAreas, boolean requireFreeSlot) {
+        clearLayout();
 		final int columns = Math.min(availableArea.width / INGREDIENT_WIDTH, Config.getMaxColumns());
 		final int rows = availableArea.height / INGREDIENT_HEIGHT;
+        if (rows <= 0 || columns < Config.smallestNumColumns) {
+            return false;
+        }
 
 		final int ingredientsWidth = columns * INGREDIENT_WIDTH;
 		final int width = Math.max(ingredientsWidth, minWidth);
@@ -76,11 +93,7 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 		final int xOffset = x + Math.max(0, (width - ingredientsWidth) / 2);
 
 		this.area = new Rectangle(x, y, width, height);
-		this.guiIngredientSlots.clear();
-
-		if (rows == 0 || columns < Config.smallestNumColumns) {
-			return false;
-		}
+        boolean hasFreeSlot = false;
 
 		for (int row = 0; row < rows; row++) {
 			List<IngredientListSlot> ingredientRow = new ArrayList<>();
@@ -91,10 +104,17 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 				Rectangle stackArea = ingredientListSlot.getArea();
 				final boolean blocked = MathUtil.intersects(exclusionAreas, stackArea);
 				ingredientListSlot.setBlocked(blocked);
+                if (!blocked) {
+                    hasFreeSlot = true;
+                }
 				ingredientRow.add(ingredientListSlot);
 			}
 			this.guiIngredientSlots.add(ingredientRow);
 		}
+        if (requireFreeSlot && !hasFreeSlot) {
+            clearLayout();
+            return false;
+        }
 		return true;
 	}
 

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
@@ -6,8 +6,13 @@ import mezz.jei.gui.GuiScreenHelper;
 import mezz.jei.gui.PageNavigation;
 import mezz.jei.gui.ghost.IGhostIngredientDragSource;
 import mezz.jei.gui.ingredients.IIngredientListElement;
+import mezz.jei.gui.navigation.NavigationLayout;
 import mezz.jei.gui.recipes.RecipesGui;
-import mezz.jei.input.*;
+import mezz.jei.input.IClickedIngredient;
+import mezz.jei.input.IMouseHandler;
+import mezz.jei.input.IPaged;
+import mezz.jei.input.IShowsRecipeFocuses;
+import mezz.jei.input.MouseHelper;
 import mezz.jei.render.IngredientListBatchRenderer;
 import mezz.jei.render.IngredientListSlot;
 import mezz.jei.render.IngredientRenderer;
@@ -20,7 +25,7 @@ import net.minecraft.client.settings.GameSettings;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -60,35 +65,54 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 		this.navigation.updatePageState();
 	}
 
-	public boolean updateBounds(Rectangle availableArea, Set<Rectangle> guiExclusionAreas, int minWidth) {
-		Rectangle estimatedNavigationArea = new Rectangle(
-			availableArea.x,
-			availableArea.y,
-			availableArea.width,
-			NAVIGATION_HEIGHT
-		);
-		Rectangle movedNavigationArea = MathUtil.moveDownToAvoidIntersection(guiExclusionAreas, estimatedNavigationArea);
-		int navigationMaxY = movedNavigationArea.y + movedNavigationArea.height;
-		Rectangle boundsWithoutNavigation = new Rectangle(
-			availableArea.x,
-			navigationMaxY,
-			availableArea.width,
-			availableArea.height - navigationMaxY
-		);
-		boolean gridHasRoom = this.ingredientGrid.updateBounds(boundsWithoutNavigation, minWidth, guiExclusionAreas);
-		if (!gridHasRoom) {
-			return false;
-		}
-		Rectangle displayArea = this.ingredientGrid.getArea();
-		Rectangle navigationArea = new Rectangle(displayArea.x, movedNavigationArea.y, displayArea.width, NAVIGATION_HEIGHT);
-		this.navigation.updateBounds(navigationArea);
-		this.area = displayArea.union(navigationArea);
-		return true;
-	}
+    public boolean updateBounds(Rectangle availableArea, Set<Rectangle> guiExclusionAreas, int minWidth) {
+        clearLayout();
 
-	public void invalidateBuffer() {
-		this.ingredientGrid.invalidateBuffer();
-	}
+        Rectangle initialContentArea = new Rectangle(
+            availableArea.x,
+            availableArea.y + NAVIGATION_HEIGHT,
+            availableArea.width,
+            availableArea.height - NAVIGATION_HEIGHT
+        );
+        if (!this.ingredientGrid.updateBoundsForNavigation(initialContentArea, minWidth, guiExclusionAreas)) {
+            return false;
+        }
+
+        int maximumNavigationWidth = this.ingredientGrid.getArea().width;
+        NavigationLayout.Result layout = NavigationLayout.calculate(
+            availableArea,
+            guiExclusionAreas,
+            NavigationLayout.Alignment.RIGHT,
+            NAVIGATION_HEIGHT,
+            minWidth,
+            maximumNavigationWidth
+        );
+        if (layout == null) {
+            clearLayout();
+            return false;
+        }
+
+        if (!this.ingredientGrid.updateBounds(layout.getContentArea(), minWidth, guiExclusionAreas)) {
+            clearLayout();
+            return false;
+        }
+
+        Rectangle displayArea = this.ingredientGrid.getArea();
+        Rectangle navigationArea = layout.getNavigationArea();
+        this.navigation.updateBounds(navigationArea);
+        this.area = displayArea.union(navigationArea);
+        return true;
+    }
+
+    private void clearLayout() {
+        this.area = new Rectangle();
+        this.navigation.updateBounds(new Rectangle());
+        this.ingredientGrid.clearLayout();
+    }
+
+    public void invalidateBuffer() {
+        this.ingredientGrid.invalidateBuffer();
+    }
 
 	public Rectangle getArea() {
 		return this.area;

--- a/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
@@ -26,7 +26,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.List;
 import java.util.Set;
 
@@ -116,59 +116,47 @@ public class IngredientListOverlay implements IIngredientListOverlay, IMouseHand
 
 				hasRoom = this.contents.updateBounds(availableContentsArea, guiExclusionAreas, 4 * BUTTON_SIZE);
 
-				// update area to match contents size
-				Rectangle contentsArea = this.contents.getArea();
-				displayArea.x = contentsArea.x;
-				displayArea.width = contentsArea.width;
+				final int visibleButtonSize = Config.hideBottomRightCornerConfigButton() ? 0 : BUTTON_SIZE;
+				Rectangle searchArea;
+				int configButtonX;
+				int configButtonY;
+				if (hasRoom) {
+                    // update area to match contents size
+					Rectangle contentsArea = this.contents.getArea();
+					displayArea.x = contentsArea.x;
+					displayArea.width = contentsArea.width;
 
-				if (Config.hideBottomRightCornerConfigButton()) {
-					if (searchBarCentered && isListDisplayed())
-						searchField.updateBounds(new Rectangle(
-							guiProperties.getGuiLeft(),
-							guiProperties.getScreenHeight() - SEARCH_HEIGHT - BORDER_PADDING,
-							guiProperties.getGuiXSize() + 1,
-							SEARCH_HEIGHT
-						));
-					else
-						searchField.updateBounds(new Rectangle(
-							displayArea.x,
-							displayArea.y + displayArea.height - SEARCH_HEIGHT - BORDER_PADDING,
-							displayArea.width + 1,
-							SEARCH_HEIGHT
-						));
-				}
-				else {
-					if (searchBarCentered && isListDisplayed())
-						searchField.updateBounds(new Rectangle(
-							guiProperties.getGuiLeft(),
-							guiProperties.getScreenHeight() - SEARCH_HEIGHT - BORDER_PADDING,
-							guiProperties.getGuiXSize() - BUTTON_SIZE + 1,
-							SEARCH_HEIGHT
-						));
-					else
-						searchField.updateBounds(new Rectangle(
-							displayArea.x,
-							displayArea.y + displayArea.height - SEARCH_HEIGHT - BORDER_PADDING,
-							displayArea.width - BUTTON_SIZE + 1,
-							SEARCH_HEIGHT
-						));
-				}
-
-				if (Config.hideBottomRightCornerConfigButton()) {
-					this.configButton.updateBounds(new Rectangle(
-							searchField.x + searchField.width - 1,
-							searchField.y,
-							0,
-							0
-					));
+					boolean centerSearchBar = searchBarCentered && isListDisplayed();
+					int searchX = centerSearchBar ? guiProperties.getGuiLeft() : displayArea.x;
+					int searchY = centerSearchBar ?
+						guiProperties.getScreenHeight() - SEARCH_HEIGHT - BORDER_PADDING :
+						displayArea.y + displayArea.height - SEARCH_HEIGHT - BORDER_PADDING;
+					int availableSearchWidth = centerSearchBar ? guiProperties.getGuiXSize() : displayArea.width;
+					searchArea = new Rectangle(
+						searchX,
+						searchY,
+						availableSearchWidth - visibleButtonSize + 1,
+						SEARCH_HEIGHT
+					);
+					configButtonX = searchArea.x + searchArea.width - 1;
+					configButtonY = searchArea.y;
 				} else {
-					this.configButton.updateBounds(new Rectangle(
-							searchField.x + searchField.width - 1,
-							searchField.y,
-							BUTTON_SIZE,
-							BUTTON_SIZE
-					));
+					searchArea = new Rectangle();
+					if (visibleButtonSize == 0) {
+						configButtonX = 0;
+						configButtonY = 0;
+					} else {
+						configButtonX = (int) Math.floor(displayArea.getMaxX()) - visibleButtonSize;
+						configButtonY = (int) Math.floor(displayArea.getMaxY()) - visibleButtonSize - BORDER_PADDING;
+					}
 				}
+				this.searchField.updateBounds(searchArea);
+				this.configButton.updateBounds(new Rectangle(
+					configButtonX,
+					configButtonY,
+					visibleButtonSize,
+					visibleButtonSize
+				));
 				updateLayout(false);
 			}
 		}

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGrid.java
@@ -5,12 +5,16 @@ import mezz.jei.config.Config;
 import mezz.jei.gui.overlay.GridAlignment;
 import mezz.jei.gui.overlay.IngredientGrid;
 import mezz.jei.gui.overlay.bookmarks.group.BookmarkGroupOrganizer;
-import mezz.jei.render.*;
+import mezz.jei.render.BookmarkListBatchRenderer;
+import mezz.jei.render.CollapsedGroupRenderer;
+import mezz.jei.render.IngredientListBatchRenderer;
+import mezz.jei.render.IngredientListSlot;
+import mezz.jei.render.IngredientRenderer;
 import mezz.jei.util.CollapsedClickAction;
 import mezz.jei.util.MathUtil;
 import net.minecraft.client.gui.GuiScreen;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -25,9 +29,28 @@ public class BookmarkGrid extends IngredientGrid {
 		this.alignment = alignment;
 	}
 
+	@Override
+	public void clearLayout() {
+		super.clearLayout();
+		this.area = new Rectangle();
+	}
+
+	boolean updateBoundsForNavigation(Rectangle availableArea, int minWidth, Collection<Rectangle> exclusionAreas) {
+		return updateBounds(availableArea, minWidth, exclusionAreas, false);
+	}
+
+	@Override
 	public boolean updateBounds(Rectangle availableArea, int minWidth, Collection<Rectangle> exclusionAreas) {
+		return updateBounds(availableArea, minWidth, exclusionAreas, true);
+	}
+
+	private boolean updateBounds(Rectangle availableArea, int minWidth, Collection<Rectangle> exclusionAreas, boolean requireFreeSlot) {
+		clearLayout();
 		final int columns = Math.min(availableArea.width / INGREDIENT_WIDTH, Config.getMaxColumns());
 		final int rows = availableArea.height / INGREDIENT_HEIGHT;
+		if (rows <= 0 || columns < Config.smallestNumColumns) {
+			return false;
+		}
 
 		final int ingredientsWidth = columns * INGREDIENT_WIDTH;
 		final int width = Math.max(ingredientsWidth, minWidth);
@@ -42,11 +65,7 @@ public class BookmarkGrid extends IngredientGrid {
 		final int xOffset = x + Math.max(0, (width - ingredientsWidth) / 2);
 
 		this.area = new Rectangle(x, y, width, height);
-		this.guiIngredientSlots.clear();
-
-		if (rows == 0 || columns < Config.smallestNumColumns) {
-			return false;
-		}
+		boolean hasFreeSlot = false;
 
 		for (int row = 0; row < rows; row++) {
 			int y1 = y + (row * INGREDIENT_HEIGHT);
@@ -57,9 +76,16 @@ public class BookmarkGrid extends IngredientGrid {
 				Rectangle stackArea = ingredientListSlot.getArea();
 				final boolean blocked = MathUtil.intersects(exclusionAreas, stackArea);
 				ingredientListSlot.setBlocked(blocked);
+				if (!blocked) {
+					hasFreeSlot = true;
+				}
 				ingredientRow.add(ingredientListSlot);
 			}
 			this.guiIngredientSlots.add(ingredientRow);
+		}
+		if (requireFreeSlot && !hasFreeSlot) {
+			clearLayout();
+			return false;
 		}
 		return true;
 	}

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkGridWithNavigation.java
@@ -8,6 +8,7 @@ import mezz.jei.gui.GuiScreenHelper;
 import mezz.jei.gui.PageNavigation;
 import mezz.jei.gui.ghost.IGhostIngredientDragSource;
 import mezz.jei.gui.ingredients.IIngredientListElement;
+import mezz.jei.gui.navigation.NavigationLayout;
 import mezz.jei.gui.overlay.GridAlignment;
 import mezz.jei.gui.overlay.IIngredientGridSource;
 import mezz.jei.gui.overlay.bookmarks.group.BookmarkGroupOrganizer;
@@ -16,14 +17,13 @@ import mezz.jei.input.IMouseHandler;
 import mezz.jei.input.IPaged;
 import mezz.jei.input.IShowsRecipeFocuses;
 import mezz.jei.render.BookmarkListBatchRenderer;
-import mezz.jei.util.MathUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import org.lwjgl.input.Keyboard;
 
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -93,36 +93,58 @@ public class BookmarkGridWithNavigation implements IShowsRecipeFocuses, IMouseHa
 	}
 
 	public boolean updateBounds(Rectangle availableArea, Set<Rectangle> guiExclusionAreas, int minWidth) {
-		Rectangle estimatedNavigationArea = new Rectangle(
-				availableArea.x,
-				availableArea.y,
-				availableArea.width,
-				NAVIGATION_HEIGHT
+		clearLayout();
+
+		int bookmarkTabWidth = Config.areRecipeBookmarksEnabled() ? BOOKMARK_TAB_WIDTH : 0;
+		Rectangle initialContentArea = new Rectangle(
+			availableArea.x + bookmarkTabWidth,
+			availableArea.y + NAVIGATION_HEIGHT,
+			availableArea.width - bookmarkTabWidth,
+			availableArea.height - NAVIGATION_HEIGHT
 		);
-		Rectangle movedNavigationArea = MathUtil.moveDownToAvoidIntersection(guiExclusionAreas, estimatedNavigationArea);
-		int navigationMaxY = movedNavigationArea.y + movedNavigationArea.height;
-		Rectangle boundsWithoutNavigation = new Rectangle(
-				availableArea.x + (Config.areRecipeBookmarksEnabled() ? BOOKMARK_TAB_WIDTH : 0),
-				navigationMaxY,
-				availableArea.width - (Config.areRecipeBookmarksEnabled() ? BOOKMARK_TAB_WIDTH : 0),
-				availableArea.height - navigationMaxY
-		);
-		Rectangle groupOrganizerBounds = new Rectangle(
-				availableArea.x,
-				navigationMaxY,
-				availableArea.width,
-				availableArea.height - navigationMaxY
-		);
-		boolean gridHasRoom = this.bookmarkGrid.updateBounds(boundsWithoutNavigation, minWidth, guiExclusionAreas);
-		if (!gridHasRoom) {
+		if (!this.bookmarkGrid.updateBoundsForNavigation(initialContentArea, minWidth, guiExclusionAreas)) {
 			return false;
 		}
+
+		int maximumNavigationWidth = this.bookmarkGrid.getArea().width;
+		NavigationLayout.Result layout = NavigationLayout.calculate(
+			availableArea,
+			guiExclusionAreas,
+			NavigationLayout.Alignment.LEFT,
+			NAVIGATION_HEIGHT,
+			minWidth,
+			maximumNavigationWidth
+		);
+		if (layout == null) {
+			clearLayout();
+			return false;
+		}
+
+		Rectangle contentArea = layout.getContentArea();
+		Rectangle gridContentArea = new Rectangle(
+			contentArea.x + bookmarkTabWidth,
+			contentArea.y,
+			contentArea.width - bookmarkTabWidth,
+			contentArea.height
+		);
+		if (!this.bookmarkGrid.updateBounds(gridContentArea, minWidth, guiExclusionAreas)) {
+			clearLayout();
+			return false;
+		}
+
 		Rectangle displayArea = this.bookmarkGrid.getArea();
-		Rectangle navigationArea = new Rectangle(2, movedNavigationArea.y, displayArea.width, NAVIGATION_HEIGHT);
+		Rectangle navigationArea = layout.getNavigationArea();
 		this.navigation.updateBounds(navigationArea);
-		this.groupOrganizer.updateBounds(groupOrganizerBounds);
+		this.groupOrganizer.updateBounds(contentArea);
 		this.area = displayArea.union(navigationArea);
 		return true;
+	}
+
+	private void clearLayout() {
+		this.area = new Rectangle();
+		this.navigation.updateBounds(new Rectangle());
+		this.bookmarkGrid.clearLayout();
+		this.groupOrganizer.clearLayout();
 	}
 
 	public Rectangle getArea() {

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
@@ -18,7 +18,7 @@ import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.Set;
 
 public class BookmarkOverlay implements ILeftAreaContent, IBookmarkOverlay {
@@ -94,10 +94,6 @@ public class BookmarkOverlay implements ILeftAreaContent, IBookmarkOverlay {
 		displayArea = new Rectangle(parentArea);
 
 		final int minWidth = getMinWidth();
-		if (displayArea.width < minWidth) {
-			return false;
-		}
-
 		Rectangle availableContentsArea = new Rectangle(
 			displayArea.x,
 			displayArea.y,
@@ -106,10 +102,12 @@ public class BookmarkOverlay implements ILeftAreaContent, IBookmarkOverlay {
 		);
 		boolean contentsHasRoom = this.contents.updateBounds(availableContentsArea, guiExclusionAreas, minWidth);
 
-		// update area to match contents size
-		Rectangle contentsArea = this.contents.getArea();
-		displayArea.x = contentsArea.x;
-		displayArea.width = contentsArea.width;
+        if (contentsHasRoom) {
+            // update area to match contents size
+            Rectangle contentsArea = this.contents.getArea();
+            displayArea.x = contentsArea.x;
+            displayArea.width = contentsArea.width;
+        }
 
         if (Config.hideBottomLeftCornerBookmarkButton()) {
             this.bookmarkButton.updateBounds(new Rectangle(0, 0, 0, 0));

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupOrganizer.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/group/BookmarkGroupOrganizer.java
@@ -23,7 +23,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.input.Keyboard;
 
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,6 +52,17 @@ public class BookmarkGroupOrganizer {
 
 	public void updateBounds(Rectangle availableArea) {
 		this.area = availableArea;
+	}
+
+	public void clearLayout() {
+		this.area = new Rectangle();
+		this.groups.clear();
+		this.hoveredGroupId = -1;
+		this.missingIngredients = 0;
+		this.craftingBlocker = null;
+		this.missingIngredientRenderer.clear();
+		this.prevMouseY = 0;
+		stopDrag();
 	}
 
 	public void setBookmarkGroupIds(List<Integer> bookmarkGroupIds) {


### PR DESCRIPTION
Previously, navigation bars were checked against exclusion areas using their full width. Any partial overlap caused the entire navigation bar to move below the exclusion area, wasting significant vertical space in the bookmark and ingredient overlays.

before 
<img width="1920" height="1080" alt="91cc3d0af0ed8d849b4c8982dbbbbf45" src="https://github.com/user-attachments/assets/e7a3188c-818f-4ee4-9bb8-4065e501c390" />

after
<img width="1920" height="1080" alt="593c7bf4f18ec7745532e86b14be05a9" src="https://github.com/user-attachments/assets/2a7d8895-0a00-47b9-a212-9c589ddba702" />
