### PR TITLE
Fix texture trim handling

### DIFF
--- a/src/main/java/mezz/jei/gui/elements/DrawableNineSliceTexture.java
+++ b/src/main/java/mezz/jei/gui/elements/DrawableNineSliceTexture.java
@@ -30,6 +30,10 @@ public class DrawableNineSliceTexture {
 		int bottomHeight = info.getSliceBottom();
 		int textureWidth = info.getWidth();
 		int textureHeight = info.getHeight();
+		int trimLeft = info.getTrimLeft();
+		int trimRight = info.getTrimRight();
+		int trimTop = info.getTrimTop();
+		int trimBottom = info.getTrimBottom();
 
 		TextureManager textureManager = minecraft.getTextureManager();
 		textureManager.bindTexture(location);
@@ -41,39 +45,46 @@ public class DrawableNineSliceTexture {
 		float uSize = uMax - uMin;
 		float vSize = vMax - vMin;
 
-		float uLeft = uMin + uSize * (leftWidth / (float) textureWidth);
-		float uRight = uMax - uSize * (rightWidth / (float) textureWidth);
-		float vTop = vMin + vSize * (topHeight / (float) textureHeight);
-		float vBottom = vMax - vSize * (bottomHeight / (float) textureHeight);
+		// the effective texture area after trimming
+		float uOuterLeft = uMin + uSize * (trimLeft / (float) textureWidth);
+		float uOuterRight = uMax - uSize * (trimRight / (float) textureWidth);
+		float vOuterTop = vMin + vSize * (trimTop / (float) textureHeight);
+		float vOuterBottom = vMax - vSize * (trimBottom / (float) textureHeight);
+
+		// within the trimmed area
+		float uLeft = uOuterLeft + uSize * (leftWidth / (float) textureWidth);
+		float uRight = uOuterRight - uSize * (rightWidth / (float) textureWidth);
+		float vTop = vOuterTop + vSize * (topHeight / (float) textureHeight);
+		float vBottom = vOuterBottom - vSize * (bottomHeight / (float) textureHeight);
 
 		Tessellator tessellator = Tessellator.getInstance();
 		BufferBuilder bufferBuilder = tessellator.getBuffer();
 		bufferBuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
 
 		// left top
-		draw(bufferBuilder, uMin, vMin, uLeft, vTop, xOffset, yOffset, leftWidth, topHeight);
+		draw(bufferBuilder, uOuterLeft, vOuterTop, uLeft, vTop, xOffset, yOffset, leftWidth, topHeight);
 		// left bottom
-		draw(bufferBuilder, uMin, vBottom, uLeft, vMax, xOffset, yOffset + height - bottomHeight, leftWidth, bottomHeight);
+		draw(bufferBuilder, uOuterLeft, vBottom, uLeft, vOuterBottom, xOffset, yOffset + height - bottomHeight, leftWidth, bottomHeight);
 		// right top
-		draw(bufferBuilder, uRight, vMin, uMax, vTop, xOffset + width - rightWidth, yOffset, rightWidth, topHeight);
+		draw(bufferBuilder, uRight, vOuterTop, uOuterRight, vTop, xOffset + width - rightWidth, yOffset, rightWidth, topHeight);
 		// right bottom
-		draw(bufferBuilder, uRight, vBottom, uMax, vMax, xOffset + width - rightWidth, yOffset + height - bottomHeight, rightWidth, bottomHeight);
+		draw(bufferBuilder, uRight, vBottom, uOuterRight, vOuterBottom, xOffset + width - rightWidth, yOffset + height - bottomHeight, rightWidth, bottomHeight);
 
-		int middleWidth = textureWidth - leftWidth - rightWidth;
-		int middleHeight = textureWidth - topHeight - bottomHeight;
+		int middleWidth = textureWidth - trimLeft - trimRight - leftWidth - rightWidth;
+		int middleHeight = textureHeight - trimTop - trimBottom - topHeight - bottomHeight;
 		int tiledMiddleWidth = width - leftWidth - rightWidth;
 		int tiledMiddleHeight = height - topHeight - bottomHeight;
 		if (tiledMiddleWidth > 0) {
 			// top edge
-			drawTiled(bufferBuilder, uLeft, vMin, uRight, vTop, xOffset + leftWidth, yOffset, tiledMiddleWidth, topHeight, middleWidth, topHeight);
+			drawTiled(bufferBuilder, uLeft, vOuterTop, uRight, vTop, xOffset + leftWidth, yOffset, tiledMiddleWidth, topHeight, middleWidth, topHeight);
 			// bottom edge
-			drawTiled(bufferBuilder, uLeft, vBottom, uRight, vMax, xOffset + leftWidth, yOffset + height - bottomHeight, tiledMiddleWidth, bottomHeight, middleWidth, bottomHeight);
+			drawTiled(bufferBuilder, uLeft, vBottom, uRight, vOuterBottom, xOffset + leftWidth, yOffset + height - bottomHeight, tiledMiddleWidth, bottomHeight, middleWidth, bottomHeight);
 		}
 		if (tiledMiddleHeight > 0) {
 			// left side
-			drawTiled(bufferBuilder, uMin, vTop, uLeft, vBottom, xOffset, yOffset + topHeight, leftWidth, tiledMiddleHeight, leftWidth, middleHeight);
+			drawTiled(bufferBuilder, uOuterLeft, vTop, uLeft, vBottom, xOffset, yOffset + topHeight, leftWidth, tiledMiddleHeight, leftWidth, middleHeight);
 			// right side
-			drawTiled(bufferBuilder, uRight, vTop, uMax, vBottom, xOffset + width - rightWidth, yOffset + topHeight, rightWidth, tiledMiddleHeight, rightWidth, middleHeight);
+			drawTiled(bufferBuilder, uRight, vTop, uOuterRight, vBottom, xOffset + width - rightWidth, yOffset + topHeight, rightWidth, tiledMiddleHeight, rightWidth, middleHeight);
 		}
 		if (tiledMiddleHeight > 0 && tiledMiddleWidth > 0) {
 			// middle area

--- a/src/main/java/mezz/jei/gui/textures/TextureInfo.java
+++ b/src/main/java/mezz/jei/gui/textures/TextureInfo.java
@@ -33,10 +33,10 @@ public class TextureInfo {
 	}
 
 	public TextureInfo trim(int left, int right, int top, int bottom) {
-		this.trimLeft = sliceLeft;
-		this.trimRight = sliceRight;
-		this.trimTop = sliceTop;
-		this.trimBottom = sliceBottom;
+		this.trimLeft = left;
+		this.trimRight = right;
+		this.trimTop = top;
+		this.trimBottom = bottom;
 		return this;
 	}
 

--- a/src/main/java/mezz/jei/gui/textures/Textures.java
+++ b/src/main/java/mezz/jei/gui/textures/Textures.java
@@ -58,10 +58,8 @@ public class Textures {
 
 		this.shapelessIcon = registerGuiSprite("icons/shapeless_icon", 36, 36)
 			.trim(1, 2, 1, 1);
-		this.arrowPrevious = registerGuiSprite("icons/arrow_previous", 9, 9)
-			.trim(0, 0, 1, 1);
-		this.arrowNext = registerGuiSprite("icons/arrow_next", 9, 9)
-			.trim(0, 0, 1, 1);
+		this.arrowPrevious = registerGuiSprite("icons/arrow_previous", 9, 9);
+		this.arrowNext = registerGuiSprite("icons/arrow_next", 9, 9);
 		this.recipeTransfer = registerGuiSprite("icons/recipe_transfer", 7, 7);
 		this.favoriteDisabled = registerGuiSprite("icons/favorite_disabled", 7, 7);
 		this.favoriteEnabled = registerGuiSprite("icons/favorite_enabled", 7, 7);


### PR DESCRIPTION
- `TextureInfo#trim(int,int,int,int)` now actually uses provided args
- DrawableNineSliceTexture will now make use of texture trim params

for a 14 * 50 texture (expanded to 64*64) setup as:
```java
this.scrollbarBackground = registerGuiSprite("scrollbar_background", 64, 64)
	.trim(0, 64 - 14, 0, 64 - 50)
	.slice(1, 1, 1, 1);
```

| Before | After |
|--------|--------|
| <img width="273" height="505" alt="before" src="https://github.com/user-attachments/assets/b2f7ad9f-0fbd-4a2f-ae47-f7fe356c06bd" /> | <img width="273" height="505" alt="after" src="https://github.com/user-attachments/assets/1e8d3962-87f5-41b2-addd-23c806c7ad39" /> |

- removed `.trim(...)` call for arrow icon texture, because this breaks arrow shadow and overall shape

<img width="281" height="193" alt="after-fixing-trim" src="https://github.com/user-attachments/assets/8dfb4a63-f17b-44d4-9d7e-79dfda717e7c" />
