### PR TITLE
bookmark recipe only when not bookmarking ingredient

### DIFF
--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -413,6 +413,15 @@ public class InputHandler {
 		int mouseY = MouseHelper.getY();
 		IClickedIngredient<?> clicked = getIngredientUnderMouseForKey(mouseX, mouseY);
 		if (clicked == null) {
+			// Try bookmarking the recipe when there's no ingredient
+			RecipeLayout recipe = recipesGui.getRecipeLayout(mouseX, mouseY);
+			if (recipe != null) {
+				boolean added = recipe.addToBookmarks(addToFront);
+				if (added && !Config.isBookmarkOverlayEnabled()) {
+					Config.toggleBookmarkEnabled();
+				}
+				return added;
+			}
 			return false;
 		}
 
@@ -428,10 +437,7 @@ public class InputHandler {
 		}
 
 		final boolean added;
-		RecipeLayout layout = recipesGui.getRecipeLayout(mouseX, mouseY);
-		if (layout != null) {
-			added = layout.addToBookmarks(addToFront);
-		} else if (value instanceof CollapsedGroupIngredient) {
+		if (value instanceof CollapsedGroupIngredient) {
 			added = false;
 		} else if (newGroup) {
 			added = bookmarkList.addToNewGroup(new BookmarkItem<>(value), addToFront);


### PR DESCRIPTION
The current behaviour is, when bookmarking an ingredient, if the mouse is also on a recipe (the ingredient should then belongs to the recipe), the recipe, instead of ingredient, will get bookmarked, this means you can basically never bookmark an individual ingredient in a recipe:

https://github.com/user-attachments/assets/f67b8a27-11b8-420a-8e53-909edbbe2e8e

This PR fixed this by always bookmark ingredient when there's one, and bookmark recipe only when no ingredient is found:


https://github.com/user-attachments/assets/02a26e7a-2e88-42e2-80c6-c530a805804c

